### PR TITLE
Use reference wrapper

### DIFF
--- a/Source/Hand.cpp
+++ b/Source/Hand.cpp
@@ -20,12 +20,12 @@ namespace Mini
         return handTiles;
     }
     
-    void Hand::AddTile(const TileCRef& tile)
+    void Hand::AddTile(const Tile& tile)
     {
         handTiles.emplace_back(tile);
     }
 
-    void Hand::RemoveTile(const TileCRef& tile)
+    void Hand::RemoveTile(const Tile& tile)
     {
         auto iter = std::find(handTiles.begin(), handTiles.end(), tile);
         debug_assert(iter != handTiles.end(), "Can't find tile to remove");

--- a/Source/Hand.cpp
+++ b/Source/Hand.cpp
@@ -9,23 +9,23 @@ namespace Mini
     // ==================================================
     // class TileGroup implementation
     // ==================================================
-    Hand::Hand(const std::vector<Tile*>& initTiles)
+    Hand::Hand(const std::vector<TileCRef>& initTiles)
     {
         debug_assert(initTiles.size() == 13, "Tiles count must be 13");
         handTiles = initTiles;
     }
 
-    const std::vector<Tile*>& Hand::GetReadOnlyTiles() const
+    const std::vector<TileCRef>& Hand::GetReadOnlyTiles() const
     {
         return handTiles;
     }
     
-    void Hand::AddTile(Tile *tile)
+    void Hand::AddTile(const TileCRef& tile)
     {
         handTiles.emplace_back(tile);
     }
 
-    void Hand::RemoveTile(const Tile *tile)
+    void Hand::RemoveTile(const TileCRef& tile)
     {
         auto iter = std::find(handTiles.begin(), handTiles.end(), tile);
         debug_assert(iter != handTiles.end(), "Can't find tile to remove");

--- a/Source/Hand.h
+++ b/Source/Hand.h
@@ -10,15 +10,15 @@ namespace Mini
     class Hand
     {
     private:
-        std::vector<Tile*> handTiles;
+        std::vector<TileCRef> handTiles;
     public:
-        Hand(const std::vector<Tile*>& initTiles);
+        Hand(const std::vector<TileCRef>& initTiles);
 
         // Getters
-        const std::vector<Tile*>& GetReadOnlyTiles() const;
+        const std::vector<TileCRef>& GetReadOnlyTiles() const;
         
-        void AddTile(Tile *tile);
-        void RemoveTile(const Tile *tile);
+        void AddTile(const TileCRef& tile);
+        void RemoveTile(const TileCRef& tile);
 
         void Sort();
     };

--- a/Source/Hand.h
+++ b/Source/Hand.h
@@ -17,8 +17,8 @@ namespace Mini
         // Getters
         const std::vector<TileCRef>& GetReadOnlyTiles() const;
         
-        void AddTile(const TileCRef& tile);
-        void RemoveTile(const TileCRef& tile);
+        void AddTile(const Tile& tile);
+        void RemoveTile(const Tile& tile);
 
         void Sort();
     };

--- a/Source/Player.cpp
+++ b/Source/Player.cpp
@@ -5,17 +5,17 @@ namespace Mini
     // ==================================================
     // class Player implementation
     // ==================================================
-    Player::Player(const std::vector<Tile*>& initTiles) : pHand(initTiles)
+    Player::Player(const std::vector<TileCRef>& initTiles) : pHand(initTiles)
     {
         
     }
 
-    const std::vector<Tile*>& Player::GetReadOnlyTiles() const
+    const std::vector<TileCRef>& Player::GetReadOnlyTiles() const
     {
         return pHand.GetReadOnlyTiles();
     }
 
-    const std::vector<Tile*>& Player::GetReadOnlyDroppedTiles() const
+    const std::vector<TileCRef>& Player::GetReadOnlyDroppedTiles() const
     {
         return droppedTiles;
     }
@@ -25,17 +25,17 @@ namespace Mini
         return calledTileGroup;
     }
     
-    void Player::AddTile(Tile* tile)
+    void Player::AddTile(const TileCRef& tile)
     {
         pHand.AddTile(tile);
     }
 
-    void Player::DropTile(const Tile* tile)
+    void Player::DropTile(const TileCRef& tile)
     {
         pHand.RemoveTile(tile);
     }
 
-    void Player::AddToDroppedTile(Tile* tile)
+    void Player::AddToDroppedTile(const TileCRef& tile)
     {
         droppedTiles.emplace_back(tile);
     }
@@ -55,7 +55,7 @@ namespace Mini
         return isMenzen;
     }
 
-    void Player::OnOtherPlayerDroppedTile(Tile* tile)
+    void Player::OnOtherPlayerDroppedTile(const TileCRef& tile)
     {
         // Check Ron
         

--- a/Source/Player.cpp
+++ b/Source/Player.cpp
@@ -25,17 +25,17 @@ namespace Mini
         return calledTileGroup;
     }
     
-    void Player::AddTile(const TileCRef& tile)
+    void Player::AddTile(const Tile& tile)
     {
         pHand.AddTile(tile);
     }
 
-    void Player::DropTile(const TileCRef& tile)
+    void Player::DropTile(const Tile& tile)
     {
         pHand.RemoveTile(tile);
     }
 
-    void Player::AddToDroppedTile(const TileCRef& tile)
+    void Player::AddToDroppedTile(const Tile& tile)
     {
         droppedTiles.emplace_back(tile);
     }
@@ -55,7 +55,7 @@ namespace Mini
         return isMenzen;
     }
 
-    void Player::OnOtherPlayerDroppedTile(const TileCRef& tile)
+    void Player::OnOtherPlayerDroppedTile(const Tile& tile)
     {
         // Check Ron
         

--- a/Source/Player.h
+++ b/Source/Player.h
@@ -13,20 +13,20 @@ namespace Mini
     private:
         Hand pHand;
         std::vector<TileGroup> calledTileGroup;
-        std::vector<Tile*> droppedTiles;
+        std::vector<TileCRef> droppedTiles;
         bool isMenzen;
 
         int pScore;
     public:
-        Player(const std::vector<Tile*>& initTiles);
+        Player(const std::vector<TileCRef>& initTiles);
 
-        const std::vector<Tile*>& GetReadOnlyTiles() const;
-        const std::vector<Tile*>& GetReadOnlyDroppedTiles() const;
+        const std::vector<TileCRef>& GetReadOnlyTiles() const;
+        const std::vector<TileCRef>& GetReadOnlyDroppedTiles() const;
         const std::vector<TileGroup>& GetReadOnlyCalledTileGroup() const;
         
-        void AddTile(Tile* tile);
-        void DropTile(const Tile* tile);
-        void AddToDroppedTile(Tile* tile);
+        void AddTile(const TileCRef& tile);
+        void DropTile(const TileCRef& tile);
+        void AddToDroppedTile(const TileCRef& tile);
 
         void SortHand();
 
@@ -34,8 +34,8 @@ namespace Mini
         bool GetIsMenzen() const;
 
         // Event Handler
-        void OnOtherPlayerDroppedTile(Tile* tile);
-        void OnOtherPlayerCalledKang(Tile* tile);
+        void OnOtherPlayerDroppedTile(const TileCRef& tile);
+        void OnOtherPlayerCalledKang(const TileCRef& tile);
 
     };
 

--- a/Source/Player.h
+++ b/Source/Player.h
@@ -24,9 +24,9 @@ namespace Mini
         const std::vector<TileCRef>& GetReadOnlyDroppedTiles() const;
         const std::vector<TileGroup>& GetReadOnlyCalledTileGroup() const;
         
-        void AddTile(const TileCRef& tile);
-        void DropTile(const TileCRef& tile);
-        void AddToDroppedTile(const TileCRef& tile);
+        void AddTile(const Tile& tile);
+        void DropTile(const Tile& tile);
+        void AddToDroppedTile(const Tile& tile);
 
         void SortHand();
 
@@ -34,8 +34,8 @@ namespace Mini
         bool GetIsMenzen() const;
 
         // Event Handler
-        void OnOtherPlayerDroppedTile(const TileCRef& tile);
-        void OnOtherPlayerCalledKang(const TileCRef& tile);
+        void OnOtherPlayerDroppedTile(const Tile& tile);
+        void OnOtherPlayerCalledKang(const Tile& tile);
 
     };
 

--- a/Source/Tile.cpp
+++ b/Source/Tile.cpp
@@ -249,33 +249,43 @@ namespace Mini
     // ==================================================
     // Some functions related with Tile class implementation
     // ==================================================
-    std::vector<Tile *> GetCompleteTileLists()
+    std::vector<TileCRef> GetCompleteTileLists()
     {
-        std::vector<Tile *> ret;
+        std::vector<TileCRef> ret;
 
         for (int i = 0; i < 4; ++i)
         {
             // Wind Tiles
-            ret.emplace_back(new WindTile(WindType::East));
-            ret.emplace_back(new WindTile(WindType::South));
-            ret.emplace_back(new WindTile(WindType::West));
-            ret.emplace_back(new WindTile(WindType::North));
+            ret.emplace_back(*new WindTile(WindType::East));
+            ret.emplace_back(*new WindTile(WindType::South));
+            ret.emplace_back(*new WindTile(WindType::West));
+            ret.emplace_back(*new WindTile(WindType::North));
 
             // Dragon Tiles
-            ret.emplace_back(new DragonTile(DragonType::White));
-            ret.emplace_back(new DragonTile(DragonType::Green));
-            ret.emplace_back(new DragonTile(DragonType::Red));
+            ret.emplace_back(*new DragonTile(DragonType::White));
+            ret.emplace_back(*new DragonTile(DragonType::Green));
+            ret.emplace_back(*new DragonTile(DragonType::Red));
 
             // Number Tiles
             for (int num = 1; num <= 9; ++num)
             {
-                ret.emplace_back(new NumberTile(NumberType::Cracks, num));
-                ret.emplace_back(new NumberTile(NumberType::Bamboo, num));
-                ret.emplace_back(new NumberTile(NumberType::Dots, num));
+                ret.emplace_back(*new NumberTile(NumberType::Cracks, num));
+                ret.emplace_back(*new NumberTile(NumberType::Bamboo, num));
+                ret.emplace_back(*new NumberTile(NumberType::Dots, num));
             }
         }
 
         return ret;
+    }
+
+    bool operator == (const TileRef& a, const TileRef& b)
+    {
+        return static_cast<const Tile&>(a) == b;
+    }
+
+    bool operator == (const TileCRef& a, const TileCRef& b)
+    {
+        return static_cast<const Tile&>(a) == b;
     }
 
 } // namespace Mini

--- a/Source/Tile.cpp
+++ b/Source/Tile.cpp
@@ -31,6 +31,11 @@ namespace Mini
         return isAkaDora;
     }
 
+    Tile::operator uint8_t () const
+    {
+        return this->GetIdentifier();
+    }
+
     // ==================================================
     // class CharacterTile implementation
     // ==================================================

--- a/Source/Tile.cpp
+++ b/Source/Tile.cpp
@@ -278,14 +278,19 @@ namespace Mini
         return ret;
     }
 
-    bool operator == (const TileRef& a, const TileRef& b)
+    bool operator == (const Tile& a, const Tile& b)
     {
-        return static_cast<const Tile&>(a) == b;
+        return a.GetIdentifier() == b.GetIdentifier();
     }
 
-    bool operator == (const TileCRef& a, const TileCRef& b)
+    bool operator != (const Tile& a, const Tile& b)
     {
-        return static_cast<const Tile&>(a) == b;
+        return !(a == b);
+    }
+
+    bool operator - (const Tile& a, const Tile& b)
+    {
+        return a.GetIdentifier() - b.GetIdentifier();
     }
 
 } // namespace Mini

--- a/Source/Tile.h
+++ b/Source/Tile.h
@@ -26,6 +26,8 @@ namespace Mini
         // Getters
         bool GetIsDora() const;
         bool GetIsAkaDora() const;
+
+        operator uint8_t () const;
     };
     
     class CharacterTile : public Tile

--- a/Source/Tile.h
+++ b/Source/Tile.h
@@ -26,7 +26,6 @@ namespace Mini
         // Getters
         bool GetIsDora() const;
         bool GetIsAkaDora() const;
-
     };
     
     class CharacterTile : public Tile
@@ -124,8 +123,9 @@ namespace Mini
         WindTile(WindType::North).GetIdentifier()
     };
 
-    bool operator == (const TileRef& a, const TileRef& b);
-    bool operator == (const TileCRef& a, const TileCRef& b);
+    bool operator == (const Tile& a, const Tile& b);
+    bool operator != (const Tile& a, const Tile& b);
+    bool operator - (const Tile& a, const Tile& b);
 
 } // namespace Mini
 

--- a/Source/Tile.h
+++ b/Source/Tile.h
@@ -3,6 +3,7 @@
 
 #include <Source/Constant.h>
 
+#include <functional>
 #include <string>
 #include <vector>
 
@@ -82,8 +83,11 @@ namespace Mini
         uint8_t GetNumber() const;
     };
 
+    using TileCRef = std::reference_wrapper<const Tile>;
+    using TileRef  = std::reference_wrapper<Tile>;
+
     // Some functions related with Tile class
-    std::vector<Tile *> GetCompleteTileLists();
+    std::vector<TileCRef> GetCompleteTileLists();
 
     const static std::vector<uint8_t> YaochuuTileIdList = { 
             DragonTile(DragonType::White).GetIdentifier(),
@@ -119,6 +123,9 @@ namespace Mini
         WindTile(WindType::West).GetIdentifier(),
         WindTile(WindType::North).GetIdentifier()
     };
+
+    bool operator == (const TileRef& a, const TileRef& b);
+    bool operator == (const TileCRef& a, const TileCRef& b);
 
 } // namespace Mini
 

--- a/Source/TileGroup.cpp
+++ b/Source/TileGroup.cpp
@@ -7,13 +7,13 @@ namespace Mini
     // ==================================================
     // class TileGroup implementation
     // ==================================================
-    TileGroup::TileGroup(const TileGroupType type, const std::vector<Tile*>& tiles, Tile *calledTile, bool argIsCalled)
+    TileGroup::TileGroup(const TileGroupType type, const std::vector<TileCRef>& tiles, const std::optional<TileCRef>& calledTile, bool argIsCalled)
     {
-        std::vector<Tile*> tmpTiles = tiles;
+        auto tmpTiles = tiles;
 
         if (calledTile)
         {
-            tmpTiles.emplace_back(calledTile);
+            tmpTiles.emplace_back(calledTile.value());
         }
 
         SortTiles(tmpTiles);
@@ -21,27 +21,27 @@ namespace Mini
         if (type == TileGroupType::Head)
         {
             debug_assert(tmpTiles.size() == 2, "Head's tiles count must be 2");
-            debug_assert(tmpTiles[0]->GetIdentifier() == tmpTiles[1]->GetIdentifier(), "Head's tiles must be same");
-            debug_assert(calledTile == nullptr, "Head can't be called");
+            debug_assert(tmpTiles[0].get().GetIdentifier() == tmpTiles[1].get().GetIdentifier(), "Head's tiles must be same");
+            debug_assert(calledTile == std::nullopt, "Head can't be called");
             debug_assert(argIsCalled == false, "Head can't be called");
         }
 
         if (type == TileGroupType::Koutsu)
         {
             debug_assert(tmpTiles.size() == 3, "Koutsu's tiles count must be 3");
-            debug_assert(tmpTiles[0]->GetIdentifier() == tmpTiles[1]->GetIdentifier() && tmpTiles[1]->GetIdentifier() == tmpTiles[2]->GetIdentifier(), "Koutsu's tiles must be same");
+            debug_assert(tmpTiles[0].get().GetIdentifier() == tmpTiles[1].get().GetIdentifier() && tmpTiles[1].get().GetIdentifier() == tmpTiles[2].get().GetIdentifier(), "Koutsu's tiles must be same");
         }
 
         if (type == TileGroupType::Kangtsu)
         {
             debug_assert(tmpTiles.size() == 4, "Kangtsu's tiles count must be 3");
-            debug_assert(tmpTiles[0]->GetIdentifier() == tmpTiles[1]->GetIdentifier() && tmpTiles[1]->GetIdentifier() == tmpTiles[2]->GetIdentifier() && tmpTiles[2]->GetIdentifier() == tmpTiles[3]->GetIdentifier(), "Kangtsu's tiles must be same");
+            debug_assert(tmpTiles[0].get().GetIdentifier() == tmpTiles[1].get().GetIdentifier() && tmpTiles[1].get().GetIdentifier() == tmpTiles[2].get().GetIdentifier() && tmpTiles[2].get().GetIdentifier() == tmpTiles[3].get().GetIdentifier(), "Kangtsu's tiles must be same");
         }
 
         if (type == TileGroupType::Shuntsu)
         {
             debug_assert(tmpTiles.size() == 3, "Shuntsu's tiles count must be 3");
-            debug_assert((tmpTiles[2]->GetIdentifier() - tmpTiles[1]->GetIdentifier()) == 1 && (tmpTiles[1]->GetIdentifier() - tmpTiles[0]->GetIdentifier()) == 1, "Shuntsu's tiles must be consecutive");
+            debug_assert((tmpTiles[2].get().GetIdentifier() - tmpTiles[1].get().GetIdentifier()) == 1 && (tmpTiles[1].get().GetIdentifier() - tmpTiles[0].get().GetIdentifier()) == 1, "Shuntsu's tiles must be consecutive");
         }
 
         tgType = type;
@@ -71,7 +71,7 @@ namespace Mini
         return isCalled;
     }
 
-    const std::vector<Tile*>& TileGroup::GetReadOnlyTiles() const
+    const std::vector<TileCRef>& TileGroup::GetReadOnlyTiles() const
     {
         return tgTiles;
     }
@@ -81,7 +81,7 @@ namespace Mini
         std::string ret;
         for (auto& tile : tgTiles)
         {
-            ret += tile->ToString() + " ";
+            ret += tile.get().ToString() + " ";
         }
         return ret;
     }

--- a/Source/TileGroup.cpp
+++ b/Source/TileGroup.cpp
@@ -21,7 +21,7 @@ namespace Mini
         if (type == TileGroupType::Head)
         {
             debug_assert(tmpTiles.size() == 2, "Head's tiles count must be 2");
-            debug_assert(tmpTiles[0].get().GetIdentifier() == tmpTiles[1].get().GetIdentifier(), "Head's tiles must be same");
+            debug_assert(tmpTiles[0] == tmpTiles[1], "Head's tiles must be same");
             debug_assert(calledTile == std::nullopt, "Head can't be called");
             debug_assert(argIsCalled == false, "Head can't be called");
         }
@@ -29,19 +29,19 @@ namespace Mini
         if (type == TileGroupType::Koutsu)
         {
             debug_assert(tmpTiles.size() == 3, "Koutsu's tiles count must be 3");
-            debug_assert(tmpTiles[0].get().GetIdentifier() == tmpTiles[1].get().GetIdentifier() && tmpTiles[1].get().GetIdentifier() == tmpTiles[2].get().GetIdentifier(), "Koutsu's tiles must be same");
+            debug_assert(tmpTiles[0] == tmpTiles[1] && tmpTiles[1] == tmpTiles[2], "Koutsu's tiles must be same");
         }
 
         if (type == TileGroupType::Kangtsu)
         {
             debug_assert(tmpTiles.size() == 4, "Kangtsu's tiles count must be 3");
-            debug_assert(tmpTiles[0].get().GetIdentifier() == tmpTiles[1].get().GetIdentifier() && tmpTiles[1].get().GetIdentifier() == tmpTiles[2].get().GetIdentifier() && tmpTiles[2].get().GetIdentifier() == tmpTiles[3].get().GetIdentifier(), "Kangtsu's tiles must be same");
+            debug_assert(tmpTiles[0] == tmpTiles[1] && tmpTiles[1] == tmpTiles[2] && tmpTiles[2] == tmpTiles[3], "Kangtsu's tiles must be same");
         }
 
         if (type == TileGroupType::Shuntsu)
         {
             debug_assert(tmpTiles.size() == 3, "Shuntsu's tiles count must be 3");
-            debug_assert((tmpTiles[2].get().GetIdentifier() - tmpTiles[1].get().GetIdentifier()) == 1 && (tmpTiles[1].get().GetIdentifier() - tmpTiles[0].get().GetIdentifier()) == 1, "Shuntsu's tiles must be consecutive");
+            debug_assert((tmpTiles[2] - tmpTiles[1]) == 1 && (tmpTiles[1] - tmpTiles[0]) == 1, "Shuntsu's tiles must be consecutive");
         }
 
         tgType = type;
@@ -79,9 +79,9 @@ namespace Mini
     std::string TileGroup::ToString() const
     {
         std::string ret;
-        for (auto& tile : tgTiles)
+        for (const Tile& tile : tgTiles)
         {
-            ret += tile.get().ToString() + " ";
+            ret += tile.ToString() + " ";
         }
         return ret;
     }

--- a/Source/TileGroup.h
+++ b/Source/TileGroup.h
@@ -3,6 +3,7 @@
 
 #include <Source/Tile.h>
 
+#include <optional>
 #include <vector>
 
 namespace Mini
@@ -18,11 +19,11 @@ namespace Mini
     class TileGroup
     {
     private:
-        std::vector<Tile*> tgTiles;
+        std::vector<TileCRef> tgTiles;
         TileGroupType tgType;
         bool isCalled = false;
     public:
-        TileGroup(const TileGroupType type, const std::vector<Tile*>& tiles, Tile *calledTile = nullptr, bool argIsCalled = false);
+        TileGroup(const TileGroupType type, const std::vector<TileCRef>& tiles, const std::optional<TileCRef>& calledTile = std::nullopt, bool argIsCalled = false);
 
         // Setters
         void SetType(const TileGroupType type);
@@ -31,12 +32,15 @@ namespace Mini
         // Getters
         TileGroupType GetType() const;
         bool GetIsCalled() const;
-        const std::vector<Tile*>& GetReadOnlyTiles() const;
+        const std::vector<TileCRef>& GetReadOnlyTiles() const;
         
         std::string ToString() const;
 
         void Sort();
     };
+
+    using TileGroupRef = std::reference_wrapper<TileGroup>;
+    using TileGroupCRef = std::reference_wrapper<const TileGroup>;
 
 } // namespace Mini
 

--- a/Source/Utils.cpp
+++ b/Source/Utils.cpp
@@ -4,8 +4,8 @@
 
 namespace Mini
 {
-    void SortTiles(std::vector<Tile*>& tileList)
+    void SortTiles(std::vector<TileCRef>& tileList)
     {
-        std::sort(tileList.begin(), tileList.end(), [](const Tile* first, const Tile* second) { return first->GetIdentifier() < second->GetIdentifier(); });
+        std::sort(tileList.begin(), tileList.end(), [](const Tile& first, const Tile& second) { return first.GetIdentifier() < second.GetIdentifier(); });
     }
 } // namespace Mini

--- a/Source/Utils.h
+++ b/Source/Utils.h
@@ -15,7 +15,7 @@ namespace Mini
 #define dbgprint(fmt, args...)
 #endif
     
-    void SortTiles(std::vector<Tile*>& tileList);
+    void SortTiles(std::vector<TileCRef>& tileList);
 
 }
 

--- a/Source/Yaku.cpp
+++ b/Source/Yaku.cpp
@@ -228,7 +228,7 @@ namespace Mini
         std::vector<TileGroup> tmpTileGroupList = tileGroupList;
         if (restTileList.size() == 2) // Last one is body
         {
-            if (pickedTile.GetIdentifier() == restTileList[0].get().GetIdentifier()) // Koutsu Check
+            if (pickedTile == restTileList[0]) // Koutsu Check
             {
                 tmpTileGroupList.emplace_back(TileGroup(TileGroupType::Koutsu, { restTileList[0], restTileList[1] }, pickedTile, isRon));
             }
@@ -339,7 +339,7 @@ namespace Mini
         std::vector<TileGroup> tmpTileGroupList = tileGroupList;
         if (restTileList.size() == 2) // Last one is body
         {
-            if (pickedTile.GetIdentifier() != restTileList[0].get().GetIdentifier()) // Shuntsu Check
+            if (pickedTile != restTileList[0]) // Shuntsu Check
             {
                 tmpTileGroupList.emplace_back(TileGroup(TileGroupType::Shuntsu, { restTileList[0], restTileList[1] }, pickedTile, isRon));
             }
@@ -367,9 +367,9 @@ namespace Mini
 
                 const std::vector<TileCRef>& firstTileList  = tmpTileGroupList[i].GetReadOnlyTiles();
                 const std::vector<TileCRef>& secondTileList = tmpTileGroupList[j].GetReadOnlyTiles();
-                if (firstTileList[0].get().GetIdentifier() == secondTileList[0].get().GetIdentifier() &&
-                    firstTileList[1].get().GetIdentifier() == secondTileList[1].get().GetIdentifier() &&
-                    firstTileList[2].get().GetIdentifier() == secondTileList[2].get().GetIdentifier())
+                if (firstTileList[0] == secondTileList[0] &&
+                    firstTileList[1] == secondTileList[1] &&
+                    firstTileList[2] == secondTileList[2])
                 {
                     return GetRealScore(isMenzen);
                 }
@@ -396,7 +396,7 @@ namespace Mini
         std::vector<TileGroup> tmpTileGroupList = tileGroupList;
         if (restTileList.size() == 2) // Last one is body
         {
-            if (pickedTile.GetIdentifier() != restTileList[0].get().GetIdentifier()) // Shuntsu Check
+            if (pickedTile != restTileList[0]) // Shuntsu Check
             {
                 tmpTileGroupList.emplace_back(TileGroup(TileGroupType::Shuntsu, { restTileList[0], restTileList[1] }, pickedTile, isRon));
             }
@@ -429,9 +429,9 @@ namespace Mini
 
                 const std::vector<TileCRef>& firstTileList  = tmpTileGroupList[i].GetReadOnlyTiles();
                 const std::vector<TileCRef>& secondTileList = tmpTileGroupList[j].GetReadOnlyTiles();
-                if (firstTileList[0].get().GetIdentifier() == secondTileList[0].get().GetIdentifier() &&
-                    firstTileList[1].get().GetIdentifier() == secondTileList[1].get().GetIdentifier() &&
-                    firstTileList[2].get().GetIdentifier() == secondTileList[2].get().GetIdentifier())
+                if (firstTileList[0] == secondTileList[0] &&
+                    firstTileList[1] == secondTileList[1] &&
+                    firstTileList[2] == secondTileList[2])
                 {
                     ++ipekoCount;
                 }
@@ -463,7 +463,7 @@ namespace Mini
         std::vector<TileGroup> tmpTileGroupList = tileGroupList;
         if (restTileList.size() == 2) // Last one is body
         {
-            if (pickedTile.GetIdentifier() != restTileList[0].get().GetIdentifier()) // Shuntsu Check
+            if (pickedTile != restTileList[0]) // Shuntsu Check
             {
                 tmpTileGroupList.emplace_back(TileGroup(TileGroupType::Shuntsu, { restTileList[0], restTileList[1] }, pickedTile, isRon));
             }
@@ -479,9 +479,9 @@ namespace Mini
 
             tileGroup.Sort();
             try {
-                auto const& first  = dynamic_cast<const NumberTile&>(tileGroup.GetReadOnlyTiles()[0].get());
-                auto const& second = dynamic_cast<const NumberTile&>(tileGroup.GetReadOnlyTiles()[1].get());
-                auto const& third  = dynamic_cast<const NumberTile&>(tileGroup.GetReadOnlyTiles()[2].get());
+                auto const& first  = dynamic_cast<const NumberTile&>(static_cast<const Tile&>(tileGroup.GetReadOnlyTiles()[0]));
+                auto const& second = dynamic_cast<const NumberTile&>(static_cast<const Tile&>(tileGroup.GetReadOnlyTiles()[1]));
+                auto const& third  = dynamic_cast<const NumberTile&>(static_cast<const Tile&>(tileGroup.GetReadOnlyTiles()[2]));
 
                 if (first.GetNumber() == 1 && second.GetNumber() == 2 && third.GetNumber() == 3)
                 {
@@ -528,7 +528,7 @@ namespace Mini
         std::vector<TileGroup> tmpTileGroupList = tileGroupList;
         if (restTileList.size() == 2) // Last one is body
         {
-            if (pickedTile.GetIdentifier() != restTileList[0].get().GetIdentifier()) // Shuntsu Check
+            if (pickedTile != restTileList[0]) // Shuntsu Check
             {
                 tmpTileGroupList.emplace_back(TileGroup(TileGroupType::Shuntsu, { restTileList[0], restTileList[1] }, pickedTile, isRon));
             }
@@ -544,9 +544,9 @@ namespace Mini
 
             tileGroup.Sort();
             try {
-                const auto& first  = dynamic_cast<const NumberTile&>(tileGroup.GetReadOnlyTiles()[0].get());
-                const auto& second = dynamic_cast<const NumberTile&>(tileGroup.GetReadOnlyTiles()[1].get());
-                const auto& third  = dynamic_cast<const NumberTile&>(tileGroup.GetReadOnlyTiles()[2].get());
+                const auto& first  = dynamic_cast<const NumberTile&>(static_cast<const Tile&>(tileGroup.GetReadOnlyTiles()[0]));
+                const auto& second = dynamic_cast<const NumberTile&>(static_cast<const Tile&>(tileGroup.GetReadOnlyTiles()[1]));
+                const auto& third  = dynamic_cast<const NumberTile&>(static_cast<const Tile&>(tileGroup.GetReadOnlyTiles()[2]));
 
                 const int key = first.GetNumber() | second.GetNumber() << 2 | third.GetNumber() << 4;
                 if (auto iter = sanshokuDoujunPair.find(key); iter !=sanshokuDoujunPair.end())
@@ -616,7 +616,7 @@ namespace Mini
         std::vector<TileGroup> tmpTileGroupList = tileGroupList;
         if (restTileList.size() == 2) // Last one is body
         {
-            if (pickedTile.GetIdentifier() == restTileList[0].get().GetIdentifier()) // Koutsu Check
+            if (pickedTile == restTileList[0]) // Koutsu Check
             {
                 tmpTileGroupList.emplace_back(TileGroup(TileGroupType::Koutsu, { restTileList[0], restTileList[1] }, pickedTile, isRon));
             }
@@ -632,7 +632,7 @@ namespace Mini
 
             // used pointer to check if it's number tile
             // to avoid using try catch for branching
-            auto const* first_ptr  = dynamic_cast<const NumberTile*>(&tileGroup.GetReadOnlyTiles()[0].get());
+            auto const* first_ptr  = dynamic_cast<const NumberTile*>(&static_cast<const Tile&>(tileGroup.GetReadOnlyTiles()[0]));
             if (first_ptr == nullptr) // It's not NumberTile
             {
                 continue;
@@ -922,7 +922,7 @@ namespace Mini
         // Check TileGroupList
         for (auto& tileGroup : tileGroupList)
         {
-            const auto* tile_ptr = dynamic_cast<const NumberTile*>(&tileGroup.GetReadOnlyTiles()[0].get());
+            const auto* tile_ptr = dynamic_cast<const NumberTile*>(&static_cast<const Tile&>(tileGroup.GetReadOnlyTiles()[0]));
             if (tile_ptr == nullptr)
             {
                 continue;
@@ -984,7 +984,7 @@ namespace Mini
         // Check TileGroupList
         for (auto& tileGroup : tileGroupList)
         {
-            const auto* tile_ptr = dynamic_cast<const NumberTile*>(&tileGroup.GetReadOnlyTiles()[0].get());
+            const auto* tile_ptr = dynamic_cast<const NumberTile*>(&static_cast<const Tile&>(tileGroup.GetReadOnlyTiles()[0]));
             if (tile_ptr == nullptr)
             {
                 return 0;
@@ -1083,7 +1083,7 @@ namespace Mini
         std::vector<TileGroup> tmpTileGroupList = tileGroupList;
         if (restTileList.size() == 2) // Last one is body
         {
-            if (pickedTile.GetIdentifier() == restTileList[0].get().GetIdentifier()) // Koutsu Check
+            if (pickedTile == restTileList[0]) // Koutsu Check
             {
                 tmpTileGroupList.emplace_back(TileGroup(TileGroupType::Koutsu, { restTileList[0], restTileList[1] }, pickedTile, isRon));
             }
@@ -1117,7 +1117,7 @@ namespace Mini
         std::vector<TileGroup> tmpTileGroupList = tileGroupList;
         if (restTileList.size() == 2) // Last one is body
         {
-            if (pickedTile.GetIdentifier() == restTileList[0].get().GetIdentifier()) // Koutsu Check
+            if (pickedTile == restTileList[0]) // Koutsu Check
             {
                 tmpTileGroupList.emplace_back(TileGroup(TileGroupType::Koutsu, { restTileList[0], restTileList[1] }, pickedTile, isRon));
             }
@@ -1160,7 +1160,7 @@ namespace Mini
         std::vector<TileGroup> tmpTileGroupList = tileGroupList;
         if (restTileList.size() == 2) // Last one is body
         {
-            if (pickedTile.GetIdentifier() == restTileList[0].get().GetIdentifier()) // Koutsu Check
+            if (pickedTile == restTileList[0]) // Koutsu Check
             {
                 tmpTileGroupList.emplace_back(TileGroup(TileGroupType::Koutsu, { restTileList[0], restTileList[1] }, pickedTile, isRon));
             }

--- a/Source/Yaku.h
+++ b/Source/Yaku.h
@@ -10,11 +10,11 @@ namespace Mini
     struct ReassembledTileGroup
     {
         std::vector<TileGroup> tileGroupList;
-        std::vector<Tile*> restTiles;
+        std::vector<TileCRef> restTiles;
     };
 
-    bool CheckChitoitsuPossible(const std::vector<TileGroup>& calledTileGroupList, const std::vector<Tile*>& handTiles, const Tile* pickedTile, ReassembledTileGroup& result);
-    bool CheckKokushimusouPossible(const std::vector<TileGroup>& calledTileGroupList, const std::vector<Tile*>& handTiles, const Tile* pickedTile, ReassembledTileGroup& result);
+    bool CheckChitoitsuPossible(const std::vector<TileGroup>& calledTileGroupList, const std::vector<TileCRef>& handTiles, const Tile& pickedTile, ReassembledTileGroup& result);
+    bool CheckKokushimusouPossible(const std::vector<TileGroup>& calledTileGroupList, const std::vector<TileCRef>& handTiles, const Tile& pickedTile, ReassembledTileGroup& result);
 
     /*
     *  Some Yaku, such as Ipeko and Ryanpeko can't be counted at the same time
@@ -48,147 +48,147 @@ namespace Mini
         int GetScore() const;
         int GetRealScore(bool isMenzen) const;
 
-        virtual int GetScoreIfPossible(const ReassembledTileGroup& reassembledTileGroup, Tile* pickedTile, bool isMenzen, bool isRon, WindType roundWind, WindType selfWind) = 0;
+        virtual int GetScoreIfPossible(const ReassembledTileGroup& reassembledTileGroup, const Tile& pickedTile, bool isMenzen, bool isRon, WindType roundWind, WindType selfWind) = 0;
     };
 
     class Menzen : public Yaku
     {
     public:
         Menzen(std::string argIdentifier, int argMenzenScore, int argScore, YakuType argYakuType) : Yaku(argIdentifier, argMenzenScore, argScore, argYakuType) { };
-        virtual int GetScoreIfPossible(const ReassembledTileGroup& reassembledTileGroup, Tile* pickedTile, bool isMenzen, bool isRon, WindType roundWind, WindType selfWind);
+        virtual int GetScoreIfPossible(const ReassembledTileGroup& reassembledTileGroup, const Tile& pickedTile, bool isMenzen, bool isRon, WindType roundWind, WindType selfWind);
     };
 
     class Yakuhai : public Yaku
     {
     public:
         Yakuhai(std::string argIdentifier, int argMenzenScore, int argScore, YakuType argYakuType) : Yaku(argIdentifier, argMenzenScore, argScore, argYakuType) { };
-        virtual int GetScoreIfPossible(const ReassembledTileGroup& reassembledTileGroup, Tile* pickedTile, bool isMenzen, bool isRon, WindType roundWind, WindType selfWind);
+        virtual int GetScoreIfPossible(const ReassembledTileGroup& reassembledTileGroup, const Tile& pickedTile, bool isMenzen, bool isRon, WindType roundWind, WindType selfWind);
     };
 
     class Tanyao : public Yaku
     {
     public:
         Tanyao(std::string argIdentifier, int argMenzenScore, int argScore, YakuType argYakuType) : Yaku(argIdentifier, argMenzenScore, argScore, argYakuType) { };
-        virtual int GetScoreIfPossible(const ReassembledTileGroup& reassembledTileGroup, Tile* pickedTile, bool isMenzen, bool isRon, WindType roundWind, WindType selfWind);
+        virtual int GetScoreIfPossible(const ReassembledTileGroup& reassembledTileGroup, const Tile& pickedTile, bool isMenzen, bool isRon, WindType roundWind, WindType selfWind);
     };
 
     class Pinfu : public Yaku
     {
     public:
         Pinfu(std::string argIdentifier, int argMenzenScore, int argScore, YakuType argYakuType) : Yaku(argIdentifier, argMenzenScore, argScore, argYakuType) { };
-        virtual int GetScoreIfPossible(const ReassembledTileGroup& reassembledTileGroup, Tile* pickedTile, bool isMenzen, bool isRon, WindType roundWind, WindType selfWind);
+        virtual int GetScoreIfPossible(const ReassembledTileGroup& reassembledTileGroup, const Tile& pickedTile, bool isMenzen, bool isRon, WindType roundWind, WindType selfWind);
     };
 
     class Ipeko : public Yaku
     {
     public:
         Ipeko(std::string argIdentifier, int argMenzenScore, int argScore, YakuType argYakuType) : Yaku(argIdentifier, argMenzenScore, argScore, argYakuType) { };
-        virtual int GetScoreIfPossible(const ReassembledTileGroup& reassembledTileGroup, Tile* pickedTile, bool isMenzen, bool isRon, WindType roundWind, WindType selfWind);
+        virtual int GetScoreIfPossible(const ReassembledTileGroup& reassembledTileGroup, const Tile& pickedTile, bool isMenzen, bool isRon, WindType roundWind, WindType selfWind);
     };
 
     class Ryanpeko : public Yaku
     {
     public:
         Ryanpeko(std::string argIdentifier, int argMenzenScore, int argScore, YakuType argYakuType) : Yaku(argIdentifier, argMenzenScore, argScore, argYakuType) { };
-        virtual int GetScoreIfPossible(const ReassembledTileGroup& reassembledTileGroup, Tile* pickedTile, bool isMenzen, bool isRon, WindType roundWind, WindType selfWind);
+        virtual int GetScoreIfPossible(const ReassembledTileGroup& reassembledTileGroup, const Tile& pickedTile, bool isMenzen, bool isRon, WindType roundWind, WindType selfWind);
     };
 
     class Ikkitsuukan : public Yaku
     {
     public:
         Ikkitsuukan(std::string argIdentifier, int argMenzenScore, int argScore, YakuType argYakuType) : Yaku(argIdentifier, argMenzenScore, argScore, argYakuType) { };
-        virtual int GetScoreIfPossible(const ReassembledTileGroup& reassembledTileGroup, Tile* pickedTile, bool isMenzen, bool isRon, WindType roundWind, WindType selfWind);
+        virtual int GetScoreIfPossible(const ReassembledTileGroup& reassembledTileGroup, const Tile& pickedTile, bool isMenzen, bool isRon, WindType roundWind, WindType selfWind);
     };
 
     class SanshokuDoujun : public Yaku
     {
     public:
         SanshokuDoujun(std::string argIdentifier, int argMenzenScore, int argScore, YakuType argYakuType) : Yaku(argIdentifier, argMenzenScore, argScore, argYakuType) { };
-        virtual int GetScoreIfPossible(const ReassembledTileGroup& reassembledTileGroup, Tile* pickedTile, bool isMenzen, bool isRon, WindType roundWind, WindType selfWind);
+        virtual int GetScoreIfPossible(const ReassembledTileGroup& reassembledTileGroup, const Tile& pickedTile, bool isMenzen, bool isRon, WindType roundWind, WindType selfWind);
     };
 
     class SanshokuDoukou : public Yaku
     {
     public:
         SanshokuDoukou(std::string argIdentifier, int argMenzenScore, int argScore, YakuType argYakuType) : Yaku(argIdentifier, argMenzenScore, argScore, argYakuType) { };
-        virtual int GetScoreIfPossible(const ReassembledTileGroup& reassembledTileGroup, Tile* pickedTile, bool isMenzen, bool isRon, WindType roundWind, WindType selfWind);
+        virtual int GetScoreIfPossible(const ReassembledTileGroup& reassembledTileGroup, const Tile& pickedTile, bool isMenzen, bool isRon, WindType roundWind, WindType selfWind);
     };
 
     class Chanta : public Yaku
     {
     public:
         Chanta(std::string argIdentifier, int argMenzenScore, int argScore, YakuType argYakuType) : Yaku(argIdentifier, argMenzenScore, argScore, argYakuType) { };
-        virtual int GetScoreIfPossible(const ReassembledTileGroup& reassembledTileGroup, Tile* pickedTile, bool isMenzen, bool isRon, WindType roundWind, WindType selfWind);
+        virtual int GetScoreIfPossible(const ReassembledTileGroup& reassembledTileGroup, const Tile& pickedTile, bool isMenzen, bool isRon, WindType roundWind, WindType selfWind);
     };
 
     class JunChanta : public Yaku
     {
     public:
         JunChanta(std::string argIdentifier, int argMenzenScore, int argScore, YakuType argYakuType) : Yaku(argIdentifier, argMenzenScore, argScore, argYakuType) { };
-        virtual int GetScoreIfPossible(const ReassembledTileGroup& reassembledTileGroup, Tile* pickedTile, bool isMenzen, bool isRon, WindType roundWind, WindType selfWind);
+        virtual int GetScoreIfPossible(const ReassembledTileGroup& reassembledTileGroup, const Tile& pickedTile, bool isMenzen, bool isRon, WindType roundWind, WindType selfWind);
     };
 
     class HonRoutou : public Yaku
     {
     public:
         HonRoutou(std::string argIdentifier, int argMenzenScore, int argScore, YakuType argYakuType) : Yaku(argIdentifier, argMenzenScore, argScore, argYakuType) { };
-        virtual int GetScoreIfPossible(const ReassembledTileGroup& reassembledTileGroup, Tile* pickedTile, bool isMenzen, bool isRon, WindType roundWind, WindType selfWind);
+        virtual int GetScoreIfPossible(const ReassembledTileGroup& reassembledTileGroup, const Tile& pickedTile, bool isMenzen, bool isRon, WindType roundWind, WindType selfWind);
     };
 
     class ChinRoutou : public Yaku
     {
     public:
         ChinRoutou(std::string argIdentifier, int argMenzenScore, int argScore, YakuType argYakuType) : Yaku(argIdentifier, argMenzenScore, argScore, argYakuType) { };
-        virtual int GetScoreIfPossible(const ReassembledTileGroup& reassembledTileGroup, Tile* pickedTile, bool isMenzen, bool isRon, WindType roundWind, WindType selfWind);
+        virtual int GetScoreIfPossible(const ReassembledTileGroup& reassembledTileGroup, const Tile& pickedTile, bool isMenzen, bool isRon, WindType roundWind, WindType selfWind);
     };
 
     class Tsuuiisou : public Yaku
     {
     public:
         Tsuuiisou(std::string argIdentifier, int argMenzenScore, int argScore, YakuType argYakuType) : Yaku(argIdentifier, argMenzenScore, argScore, argYakuType) { };
-        virtual int GetScoreIfPossible(const ReassembledTileGroup& reassembledTileGroup, Tile* pickedTile, bool isMenzen, bool isRon, WindType roundWind, WindType selfWind);
+        virtual int GetScoreIfPossible(const ReassembledTileGroup& reassembledTileGroup, const Tile& pickedTile, bool isMenzen, bool isRon, WindType roundWind, WindType selfWind);
     };
 
     class Honiisou : public Yaku
     {
     public:
         Honiisou(std::string argIdentifier, int argMenzenScore, int argScore, YakuType argYakuType) : Yaku(argIdentifier, argMenzenScore, argScore, argYakuType) { };
-        virtual int GetScoreIfPossible(const ReassembledTileGroup& reassembledTileGroup, Tile* pickedTile, bool isMenzen, bool isRon, WindType roundWind, WindType selfWind);
+        virtual int GetScoreIfPossible(const ReassembledTileGroup& reassembledTileGroup, const Tile& pickedTile, bool isMenzen, bool isRon, WindType roundWind, WindType selfWind);
     };
 
     class Chiniisou : public Yaku
     {
     public:
         Chiniisou(std::string argIdentifier, int argMenzenScore, int argScore, YakuType argYakuType) : Yaku(argIdentifier, argMenzenScore, argScore, argYakuType) { };
-        virtual int GetScoreIfPossible(const ReassembledTileGroup& reassembledTileGroup, Tile* pickedTile, bool isMenzen, bool isRon, WindType roundWind, WindType selfWind);
+        virtual int GetScoreIfPossible(const ReassembledTileGroup& reassembledTileGroup, const Tile& pickedTile, bool isMenzen, bool isRon, WindType roundWind, WindType selfWind);
     };
 
     class Chitoitsu : public Yaku
     {
     public:
         Chitoitsu(std::string argIdentifier, int argMenzenScore, int argScore, YakuType argYakuType) : Yaku(argIdentifier, argMenzenScore, argScore, argYakuType) { };
-        virtual int GetScoreIfPossible(const ReassembledTileGroup& reassembledTileGroup, Tile* pickedTile, bool isMenzen, bool isRon, WindType roundWind, WindType selfWind);
+        virtual int GetScoreIfPossible(const ReassembledTileGroup& reassembledTileGroup, const Tile& pickedTile, bool isMenzen, bool isRon, WindType roundWind, WindType selfWind);
     };
 
     class Toitoi : public Yaku
     {
     public:
         Toitoi(std::string argIdentifier, int argMenzenScore, int argScore, YakuType argYakuType) : Yaku(argIdentifier, argMenzenScore, argScore, argYakuType) { };
-        virtual int GetScoreIfPossible(const ReassembledTileGroup& reassembledTileGroup, Tile* pickedTile, bool isMenzen, bool isRon, WindType roundWind, WindType selfWind);
+        virtual int GetScoreIfPossible(const ReassembledTileGroup& reassembledTileGroup, const Tile& pickedTile, bool isMenzen, bool isRon, WindType roundWind, WindType selfWind);
     };
 
     class Sanankou : public Yaku
     {
     public:
         Sanankou(std::string argIdentifier, int argMenzenScore, int argScore, YakuType argYakuType) : Yaku(argIdentifier, argMenzenScore, argScore, argYakuType) { };
-        virtual int GetScoreIfPossible(const ReassembledTileGroup& reassembledTileGroup, Tile* pickedTile, bool isMenzen, bool isRon, WindType roundWind, WindType selfWind);
+        virtual int GetScoreIfPossible(const ReassembledTileGroup& reassembledTileGroup, const Tile& pickedTile, bool isMenzen, bool isRon, WindType roundWind, WindType selfWind);
     };
 
     class Suuankou : public Yaku
     {
     public:
         Suuankou(std::string argIdentifier, int argMenzenScore, int argScore, YakuType argYakuType) : Yaku(argIdentifier, argMenzenScore, argScore, argYakuType) { };
-        virtual int GetScoreIfPossible(const ReassembledTileGroup& reassembledTileGroup, Tile* pickedTile, bool isMenzen, bool isRon, WindType roundWind, WindType selfWind);
+        virtual int GetScoreIfPossible(const ReassembledTileGroup& reassembledTileGroup, const Tile& pickedTile, bool isMenzen, bool isRon, WindType roundWind, WindType selfWind);
     };
 }
 

--- a/Test/Test.cpp
+++ b/Test/Test.cpp
@@ -41,22 +41,22 @@ namespace Mini
     void Test02()
     {
         puts(" ========== < Test 02 > ========== ");
-        std::vector<Tile *> tileList = GetCompleteTileLists();
+        auto tileList = GetCompleteTileLists();
         std::random_device rd; 
         std::mt19937 g(rd());
         std::shuffle(tileList.begin(), tileList.end(), g);
 
-        Hand hand(std::vector<Tile*>(tileList.begin(), tileList.begin() + 13));
+        Hand hand(std::vector(tileList.begin(), tileList.begin() + 13));
         hand.Sort();
         for (int i = 0; i < 13; ++i)
         {
-            printf(" %s", hand.GetReadOnlyTiles()[i]->ToString().c_str());
+            printf(" %s", hand.GetReadOnlyTiles()[i].get().ToString().c_str());
         }
         printf("\n\n");
 
-        for (auto& tile : tileList)
+        for (const Tile& tile : tileList)
         {
-            delete tile;
+            delete &tile;
         }
         puts(" ================================= ");
     }
@@ -66,27 +66,27 @@ namespace Mini
     */
     void Test03()
     {
-        std::vector<Tile*> orgTileList = GetCompleteTileLists();
-        std::vector<Tile*> tileList = orgTileList;
+        std::vector<TileCRef> orgTileList = GetCompleteTileLists();
+        std::vector<TileCRef> tileList = orgTileList;
         std::random_device rd; 
         std::mt19937 g(rd());
         std::shuffle(tileList.begin(), tileList.end(), g);
 
-        Player player(std::vector<Tile*>(tileList.begin(), tileList.begin() + 13));
-        tileList = std::vector<Tile*>(tileList.begin() + 13, tileList.end());
+        Player player(std::vector(tileList.begin(), tileList.begin() + 13));
+        tileList = std::vector(tileList.begin() + 13, tileList.end());
 
         while (tileList.size() != 0)
         {
-            Tile *newTile = tileList[tileList.size() - 1];
+            const Tile& newTile = tileList[tileList.size() - 1];
             tileList.pop_back();
 
             player.SortHand();
             const auto& handTiles = player.GetReadOnlyTiles();
             for (int i = 0; i < handTiles.size(); ++i)
             {
-                printf("%s ", handTiles[i]->ToString().c_str());
+                printf("%s ", handTiles[i].get().ToString().c_str());
             }
-            printf("   %s\n", newTile->ToString().c_str());
+            printf("   %s\n", newTile.ToString().c_str());
             
             int index = -1;
             while (index < 0 || index > handTiles.size())
@@ -95,26 +95,25 @@ namespace Mini
                 scanf("%d", &index);
             }
 
-            Tile *droppedTile = nullptr;
             if (index == handTiles.size())
             {
                 // Tsumogiri
-                droppedTile = newTile;
+                player.AddToDroppedTile(newTile);
             }
             else
             {
-                droppedTile = handTiles[index];
+                auto const& droppedTile = handTiles[index];
                 player.DropTile(droppedTile);
                 player.AddTile(newTile);
+                player.AddToDroppedTile(droppedTile);
             }
             
-            player.AddToDroppedTile(droppedTile);
             puts(" ----------------------------- ");
         }
 
-        for (auto& tile : orgTileList)
+        for (Tile const& tile : orgTileList)
         {
-            delete tile;
+            delete &tile;
         }
 
         puts(" ================================= ");
@@ -128,18 +127,18 @@ namespace Mini
         /* Chitoitsu Test */
         {
             puts("[  Chitoitsu Test 01  ]");
-            std::vector<Tile*> chitoitsuTest01List = { new NumberTile(NumberType::Cracks, 1), new NumberTile(NumberType::Cracks, 1), new NumberTile(NumberType::Cracks, 1),
-                                                        new NumberTile(NumberType::Cracks, 2), new NumberTile(NumberType::Cracks, 2), new NumberTile(NumberType::Bamboo, 4),
-                                                        new NumberTile(NumberType::Bamboo, 4), new NumberTile(NumberType::Dots, 8), new NumberTile(NumberType::Dots, 8),
-                                                        new WindTile(WindType::West), new WindTile(WindType::West), new DragonTile(DragonType::Red),
-                                                        new DragonTile(DragonType::Red), };
-            Tile* pickedTile = new NumberTile(NumberType::Cracks, 1);
+            std::vector<TileCRef> chitoitsuTest01List = { *new NumberTile(NumberType::Cracks, 1), *new NumberTile(NumberType::Cracks, 1), *new NumberTile(NumberType::Cracks, 1),
+                                                        *new NumberTile(NumberType::Cracks, 2), *new NumberTile(NumberType::Cracks, 2), *new NumberTile(NumberType::Bamboo, 4),
+                                                        *new NumberTile(NumberType::Bamboo, 4), *new NumberTile(NumberType::Dots, 8), *new NumberTile(NumberType::Dots, 8),
+                                                        *new WindTile(WindType::West), *new WindTile(WindType::West), *new DragonTile(DragonType::Red),
+                                                        *new DragonTile(DragonType::Red), };
+            const Tile& pickedTile = *new NumberTile(NumberType::Cracks, 1);
             printf("[*] Tiles: ");
-            for (auto& tile : chitoitsuTest01List)
+            for (const Tile& tile : chitoitsuTest01List)
             {
-                printf("%s ", tile->ToString().c_str());
+                printf("%s ", tile.ToString().c_str());
             }
-            printf("    %s\n", pickedTile->ToString().c_str());
+            printf("    %s\n", pickedTile.ToString().c_str());
 
             ReassembledTileGroup result;
             bool isPassed = CheckChitoitsuPossible({}, chitoitsuTest01List, pickedTile, result);
@@ -148,18 +147,18 @@ namespace Mini
 
         {
             puts("[  Chitoitsu Test 02  ]");
-            std::vector<Tile*> chitoitsuTest02List = { new NumberTile(NumberType::Cracks, 1), new NumberTile(NumberType::Cracks, 1), new NumberTile(NumberType::Cracks, 1),
-                                                        new NumberTile(NumberType::Cracks, 2), new NumberTile(NumberType::Cracks, 2), new NumberTile(NumberType::Bamboo, 4),
-                                                        new NumberTile(NumberType::Bamboo, 4), new NumberTile(NumberType::Dots, 8), new NumberTile(NumberType::Dots, 8),
-                                                        new WindTile(WindType::West), new WindTile(WindType::West), new DragonTile(DragonType::Red),
-                                                        new DragonTile(DragonType::Red), };
-            Tile* pickedTile = new NumberTile(NumberType::Cracks, 3);
+            std::vector<TileCRef> chitoitsuTest02List = { *new NumberTile(NumberType::Cracks, 1), *new NumberTile(NumberType::Cracks, 1), *new NumberTile(NumberType::Cracks, 1),
+                                                        *new NumberTile(NumberType::Cracks, 2), *new NumberTile(NumberType::Cracks, 2), *new NumberTile(NumberType::Bamboo, 4),
+                                                        *new NumberTile(NumberType::Bamboo, 4), *new NumberTile(NumberType::Dots, 8), *new NumberTile(NumberType::Dots, 8),
+                                                        *new WindTile(WindType::West), *new WindTile(WindType::West), *new DragonTile(DragonType::Red),
+                                                        *new DragonTile(DragonType::Red), };
+            const Tile& pickedTile = *new NumberTile(NumberType::Cracks, 3);
             printf("[*] Tiles: ");
-            for (auto& tile : chitoitsuTest02List)
+            for (const Tile& tile : chitoitsuTest02List)
             {
-                printf("%s ", tile->ToString().c_str());
+                printf("%s ", tile.ToString().c_str());
             }
-            printf("    %s\n", pickedTile->ToString().c_str());
+            printf("    %s\n", pickedTile.ToString().c_str());
 
             ReassembledTileGroup result;
             bool isPassed = CheckChitoitsuPossible({}, chitoitsuTest02List, pickedTile, result);
@@ -168,18 +167,18 @@ namespace Mini
 
         {
             puts("[  Chitoitsu Test 03  ]");
-            std::vector<Tile*> chitoitsuTest03List = { new NumberTile(NumberType::Cracks, 1), new NumberTile(NumberType::Cracks, 2), new NumberTile(NumberType::Cracks, 3),
-                                                        new NumberTile(NumberType::Cracks, 2), new NumberTile(NumberType::Cracks, 2), new NumberTile(NumberType::Bamboo, 4),
-                                                        new NumberTile(NumberType::Bamboo, 4), new NumberTile(NumberType::Dots, 8), new NumberTile(NumberType::Dots, 8),
-                                                        new WindTile(WindType::West), new WindTile(WindType::West), new DragonTile(DragonType::Red),
-                                                        new DragonTile(DragonType::Red), };
-            Tile* pickedTile = new NumberTile(NumberType::Cracks, 1);
+            std::vector<TileCRef> chitoitsuTest03List = { *new NumberTile(NumberType::Cracks, 1), *new NumberTile(NumberType::Cracks, 2), *new NumberTile(NumberType::Cracks, 3),
+                                                        *new NumberTile(NumberType::Cracks, 2), *new NumberTile(NumberType::Cracks, 2), *new NumberTile(NumberType::Bamboo, 4),
+                                                        *new NumberTile(NumberType::Bamboo, 4), *new NumberTile(NumberType::Dots, 8), *new NumberTile(NumberType::Dots, 8),
+                                                        *new WindTile(WindType::West), *new WindTile(WindType::West), *new DragonTile(DragonType::Red),
+                                                        *new DragonTile(DragonType::Red), };
+            const Tile& pickedTile = *new NumberTile(NumberType::Cracks, 1);
             printf("[*] Tiles: ");
-            for (auto& tile : chitoitsuTest03List)
+            for (const Tile& tile : chitoitsuTest03List)
             {
-                printf("%s ", tile->ToString().c_str());
+                printf("%s ", tile.ToString().c_str());
             }
-            printf("    %s\n", pickedTile->ToString().c_str());
+            printf("    %s\n", pickedTile.ToString().c_str());
 
             ReassembledTileGroup result;
             bool isPassed = CheckChitoitsuPossible({}, chitoitsuTest03List, pickedTile, result);
@@ -189,18 +188,18 @@ namespace Mini
         /* Kokushimusou Test */
         {
             puts("[  Kokushimusou Test 01  ]");
-            std::vector<Tile*> chitoitsuTest01List = { new NumberTile(NumberType::Cracks, 1), new NumberTile(NumberType::Cracks, 9), new NumberTile(NumberType::Bamboo, 1),
-                                                        new NumberTile(NumberType::Bamboo, 9), new NumberTile(NumberType::Dots, 1), new NumberTile(NumberType::Dots, 9),
-                                                        new WindTile(WindType::East), new WindTile(WindType::South), new WindTile(WindType::West),
-                                                        new WindTile(WindType::North), new DragonTile(DragonType::White), new DragonTile(DragonType::Green),
-                                                        new DragonTile(DragonType::Red), };
-            Tile* pickedTile = new NumberTile(NumberType::Cracks, 1);
+            std::vector<TileCRef> chitoitsuTest01List = { *new NumberTile(NumberType::Cracks, 1), *new NumberTile(NumberType::Cracks, 9), *new NumberTile(NumberType::Bamboo, 1),
+                                                        *new NumberTile(NumberType::Bamboo, 9), *new NumberTile(NumberType::Dots, 1), *new NumberTile(NumberType::Dots, 9),
+                                                        *new WindTile(WindType::East), *new WindTile(WindType::South), *new WindTile(WindType::West),
+                                                        *new WindTile(WindType::North), *new DragonTile(DragonType::White), *new DragonTile(DragonType::Green),
+                                                        *new DragonTile(DragonType::Red), };
+            const Tile& pickedTile = *new NumberTile(NumberType::Cracks, 1);
             printf("[*] Tiles: ");
-            for (auto& tile : chitoitsuTest01List)
+            for (const Tile& tile : chitoitsuTest01List)
             {
-                printf("%s ", tile->ToString().c_str());
+                printf("%s ", tile.ToString().c_str());
             }
-            printf("    %s\n", pickedTile->ToString().c_str());
+            printf("    %s\n", pickedTile.ToString().c_str());
 
             ReassembledTileGroup result;
             bool isPassed = CheckKokushimusouPossible({}, chitoitsuTest01List, pickedTile, result);
@@ -209,18 +208,18 @@ namespace Mini
 
         {
             puts("[  Kokushimusou Test 02  ]");
-            std::vector<Tile*> chitoitsuTest02List = { new NumberTile(NumberType::Cracks, 2), new NumberTile(NumberType::Cracks, 9), new NumberTile(NumberType::Bamboo, 1),
-                                                        new NumberTile(NumberType::Bamboo, 9), new NumberTile(NumberType::Dots, 1), new NumberTile(NumberType::Dots, 9),
-                                                        new WindTile(WindType::East), new WindTile(WindType::South), new WindTile(WindType::West),
-                                                        new WindTile(WindType::North), new DragonTile(DragonType::White), new DragonTile(DragonType::Green),
-                                                        new DragonTile(DragonType::Red), };
-            Tile* pickedTile = new NumberTile(NumberType::Cracks, 1);
+            std::vector<TileCRef> chitoitsuTest02List = { *new NumberTile(NumberType::Cracks, 2), *new NumberTile(NumberType::Cracks, 9), *new NumberTile(NumberType::Bamboo, 1),
+                                                        *new NumberTile(NumberType::Bamboo, 9), *new NumberTile(NumberType::Dots, 1), *new NumberTile(NumberType::Dots, 9),
+                                                        *new WindTile(WindType::East), *new WindTile(WindType::South), *new WindTile(WindType::West),
+                                                        *new WindTile(WindType::North), *new DragonTile(DragonType::White), *new DragonTile(DragonType::Green),
+                                                        *new DragonTile(DragonType::Red), };
+            TileCRef pickedTile = *new NumberTile(NumberType::Cracks, 1);
             printf("[*] Tiles: ");
             for (auto& tile : chitoitsuTest02List)
             {
-                printf("%s ", tile->ToString().c_str());
+                printf("%s ", tile.get().ToString().c_str());
             }
-            printf("    %s\n", pickedTile->ToString().c_str());
+            printf("    %s\n", pickedTile.get().ToString().c_str());
 
             ReassembledTileGroup result;
             bool isPassed = CheckKokushimusouPossible({}, chitoitsuTest02List, pickedTile, result);
@@ -229,18 +228,18 @@ namespace Mini
 
         {
             puts("[  Kokushimusou Test 03  ]");
-            std::vector<Tile*> chitoitsuTest03List = { new NumberTile(NumberType::Cracks, 1), new NumberTile(NumberType::Cracks, 1), new NumberTile(NumberType::Bamboo, 1),
-                                                        new NumberTile(NumberType::Bamboo, 9), new NumberTile(NumberType::Dots, 1), new NumberTile(NumberType::Dots, 9),
-                                                        new WindTile(WindType::East), new WindTile(WindType::South), new WindTile(WindType::West),
-                                                        new WindTile(WindType::North), new DragonTile(DragonType::White), new DragonTile(DragonType::Green),
-                                                        new DragonTile(DragonType::Red), };
-            Tile* pickedTile = new NumberTile(NumberType::Cracks, 9);
+            std::vector<TileCRef> chitoitsuTest03List = { *new NumberTile(NumberType::Cracks, 1), *new NumberTile(NumberType::Cracks, 1), *new NumberTile(NumberType::Bamboo, 1),
+                                                        *new NumberTile(NumberType::Bamboo, 9), *new NumberTile(NumberType::Dots, 1), *new NumberTile(NumberType::Dots, 9),
+                                                        *new WindTile(WindType::East), *new WindTile(WindType::South), *new WindTile(WindType::West),
+                                                        *new WindTile(WindType::North), *new DragonTile(DragonType::White), *new DragonTile(DragonType::Green),
+                                                        *new DragonTile(DragonType::Red), };
+            TileCRef pickedTile = *new NumberTile(NumberType::Cracks, 9);
             printf("[*] Tiles: ");
             for (auto& tile : chitoitsuTest03List)
             {
-                printf("%s ", tile->ToString().c_str());
+                printf("%s ", tile.get().ToString().c_str());
             }
-            printf("    %s\n", pickedTile->ToString().c_str());
+            printf("    %s\n", pickedTile.get().ToString().c_str());
 
             ReassembledTileGroup result;
             bool isPassed = CheckKokushimusouPossible({}, chitoitsuTest03List, pickedTile, result);
@@ -264,17 +263,17 @@ namespace Mini
             puts("[  Yaku Test 01  ]");
             ReassembledTileGroup reassembledTileGroup = {
                 { 
-                    TileGroup(TileGroupType::Head, { new NumberTile(NumberType::Cracks, 1), new NumberTile(NumberType::Cracks, 1) }, nullptr, false),
-                    TileGroup(TileGroupType::Shuntsu, { new NumberTile(NumberType::Bamboo, 2), new NumberTile(NumberType::Bamboo, 3), new NumberTile(NumberType::Bamboo, 4) }, nullptr, false),
-                    TileGroup(TileGroupType::Shuntsu, { new NumberTile(NumberType::Bamboo, 3), new NumberTile(NumberType::Bamboo, 4), new NumberTile(NumberType::Bamboo, 5) }, nullptr, false),
-                    TileGroup(TileGroupType::Shuntsu, { new NumberTile(NumberType::Dots, 6), new NumberTile(NumberType::Bamboo, 7), new NumberTile(NumberType::Bamboo, 8) }, nullptr, false),
+                    TileGroup(TileGroupType::Head, { *new NumberTile(NumberType::Cracks, 1), *new NumberTile(NumberType::Cracks, 1) }),
+                    TileGroup(TileGroupType::Shuntsu, { *new NumberTile(NumberType::Bamboo, 2), *new NumberTile(NumberType::Bamboo, 3), *new NumberTile(NumberType::Bamboo, 4) }),
+                    TileGroup(TileGroupType::Shuntsu, { *new NumberTile(NumberType::Bamboo, 3), *new NumberTile(NumberType::Bamboo, 4), *new NumberTile(NumberType::Bamboo, 5) }),
+                    TileGroup(TileGroupType::Shuntsu, { *new NumberTile(NumberType::Dots, 6), *new NumberTile(NumberType::Bamboo, 7), *new NumberTile(NumberType::Bamboo, 8) }),
                 },
                 {
-                    new NumberTile(NumberType::Dots, 6),
-                    new NumberTile(NumberType::Dots, 7)
+                    *new NumberTile(NumberType::Dots, 6),
+                    *new NumberTile(NumberType::Dots, 7)
                 }
             };
-            Tile* pickedTile = new NumberTile(NumberType::Dots, 5);
+            const Tile& pickedTile = *new NumberTile(NumberType::Dots, 5);
             bool isMenzen = true;
             bool isRon    = false;
             WindType roundWind = WindType::East;
@@ -287,17 +286,17 @@ namespace Mini
             puts("[  Yaku Test 02  ]");
             ReassembledTileGroup reassembledTileGroup = {
                 { 
-                    TileGroup(TileGroupType::Head, { new NumberTile(NumberType::Cracks, 2), new NumberTile(NumberType::Cracks, 2) }, nullptr, false),
-                    TileGroup(TileGroupType::Shuntsu, { new NumberTile(NumberType::Bamboo, 2), new NumberTile(NumberType::Bamboo, 3), new NumberTile(NumberType::Bamboo, 4) }, nullptr, false),
-                    TileGroup(TileGroupType::Shuntsu, { new NumberTile(NumberType::Bamboo, 3), new NumberTile(NumberType::Bamboo, 4), new NumberTile(NumberType::Bamboo, 5) }, nullptr, false),
-                    TileGroup(TileGroupType::Shuntsu, { new NumberTile(NumberType::Dots, 6), new NumberTile(NumberType::Bamboo, 7), new NumberTile(NumberType::Bamboo, 8) }, nullptr, false),
+                    TileGroup(TileGroupType::Head, { *new NumberTile(NumberType::Cracks, 2), *new NumberTile(NumberType::Cracks, 2) }),
+                    TileGroup(TileGroupType::Shuntsu, { *new NumberTile(NumberType::Bamboo, 2), *new NumberTile(NumberType::Bamboo, 3), *new NumberTile(NumberType::Bamboo, 4) }),
+                    TileGroup(TileGroupType::Shuntsu, { *new NumberTile(NumberType::Bamboo, 3), *new NumberTile(NumberType::Bamboo, 4), *new NumberTile(NumberType::Bamboo, 5) }),
+                    TileGroup(TileGroupType::Shuntsu, { *new NumberTile(NumberType::Dots, 6), *new NumberTile(NumberType::Bamboo, 7), *new NumberTile(NumberType::Bamboo, 8) }),
                 },
                 {
-                    new NumberTile(NumberType::Dots, 6),
-                    new NumberTile(NumberType::Dots, 7)
+                    *new NumberTile(NumberType::Dots, 6),
+                    *new NumberTile(NumberType::Dots, 7)
                 }
             };
-            Tile* pickedTile = new NumberTile(NumberType::Dots, 5);
+            TileCRef pickedTile = *new NumberTile(NumberType::Dots, 5);
             bool isMenzen = true;
             bool isRon    = false;
             WindType roundWind = WindType::East;
@@ -310,16 +309,16 @@ namespace Mini
             puts("[  Yaku Test 03  ]");
             ReassembledTileGroup reassembledTileGroup = {
                 { 
-                    TileGroup(TileGroupType::Shuntsu, { new NumberTile(NumberType::Cracks, 2), new NumberTile(NumberType::Cracks, 3), new NumberTile(NumberType::Cracks, 4) }, nullptr, false),
-                    TileGroup(TileGroupType::Shuntsu, { new NumberTile(NumberType::Bamboo, 2), new NumberTile(NumberType::Bamboo, 3), new NumberTile(NumberType::Bamboo, 4) }, nullptr, false),
-                    TileGroup(TileGroupType::Shuntsu, { new NumberTile(NumberType::Bamboo, 3), new NumberTile(NumberType::Bamboo, 4), new NumberTile(NumberType::Bamboo, 5) }, nullptr, false),
-                    TileGroup(TileGroupType::Shuntsu, { new NumberTile(NumberType::Dots, 6), new NumberTile(NumberType::Bamboo, 7), new NumberTile(NumberType::Bamboo, 8) }, nullptr, false),
+                    TileGroup(TileGroupType::Shuntsu, { *new NumberTile(NumberType::Cracks, 2), *new NumberTile(NumberType::Cracks, 3), *new NumberTile(NumberType::Cracks, 4) }),
+                    TileGroup(TileGroupType::Shuntsu, { *new NumberTile(NumberType::Bamboo, 2), *new NumberTile(NumberType::Bamboo, 3), *new NumberTile(NumberType::Bamboo, 4) }),
+                    TileGroup(TileGroupType::Shuntsu, { *new NumberTile(NumberType::Bamboo, 3), *new NumberTile(NumberType::Bamboo, 4), *new NumberTile(NumberType::Bamboo, 5) }),
+                    TileGroup(TileGroupType::Shuntsu, { *new NumberTile(NumberType::Dots, 6), *new NumberTile(NumberType::Bamboo, 7), *new NumberTile(NumberType::Bamboo, 8) }),
                 },
                 {
-                    new NumberTile(NumberType::Dots, 6),
+                    *new NumberTile(NumberType::Dots, 6),
                 }
             };
-            Tile* pickedTile = new NumberTile(NumberType::Dots, 6);
+            TileCRef pickedTile = *new NumberTile(NumberType::Dots, 6);
             bool isMenzen = true;
             bool isRon    = false;
             WindType roundWind = WindType::East;
@@ -332,17 +331,17 @@ namespace Mini
             puts("[  Yaku Test 04  ]");
             ReassembledTileGroup reassembledTileGroup = {
                 { 
-                    TileGroup(TileGroupType::Head, { new NumberTile(NumberType::Cracks, 2), new NumberTile(NumberType::Cracks, 2) }, nullptr, false),
-                    TileGroup(TileGroupType::Shuntsu, { new NumberTile(NumberType::Bamboo, 2), new NumberTile(NumberType::Bamboo, 3), new NumberTile(NumberType::Bamboo, 4) }, nullptr, false),
-                    TileGroup(TileGroupType::Shuntsu, { new NumberTile(NumberType::Bamboo, 3), new NumberTile(NumberType::Bamboo, 4), new NumberTile(NumberType::Bamboo, 5) }, nullptr, false),
-                    TileGroup(TileGroupType::Koutsu, { new WindTile(WindType::West), new WindTile(WindType::West), new WindTile(WindType::West) }, nullptr, false),
+                    TileGroup(TileGroupType::Head, { *new NumberTile(NumberType::Cracks, 2), *new NumberTile(NumberType::Cracks, 2) }),
+                    TileGroup(TileGroupType::Shuntsu, { *new NumberTile(NumberType::Bamboo, 2), *new NumberTile(NumberType::Bamboo, 3), *new NumberTile(NumberType::Bamboo, 4) }),
+                    TileGroup(TileGroupType::Shuntsu, { *new NumberTile(NumberType::Bamboo, 3), *new NumberTile(NumberType::Bamboo, 4), *new NumberTile(NumberType::Bamboo, 5) }),
+                    TileGroup(TileGroupType::Koutsu, { *new WindTile(WindType::West), *new WindTile(WindType::West), *new WindTile(WindType::West) }),
                 },
                 {
-                    new NumberTile(NumberType::Dots, 6),
-                    new NumberTile(NumberType::Dots, 7)
+                    *new NumberTile(NumberType::Dots, 6),
+                    *new NumberTile(NumberType::Dots, 7)
                 }
             };
-            Tile* pickedTile = new NumberTile(NumberType::Dots, 5);
+            TileCRef pickedTile = *new NumberTile(NumberType::Dots, 5);
             bool isMenzen = true;
             bool isRon    = true;
             WindType roundWind = WindType::East;
@@ -371,17 +370,17 @@ namespace Mini
             puts("[  Yaku Test 01  ]");
             ReassembledTileGroup reassembledTileGroup = {
                 { 
-                    TileGroup(TileGroupType::Head, { new NumberTile(NumberType::Cracks, 1), new NumberTile(NumberType::Cracks, 1) }, nullptr, false),
-                    TileGroup(TileGroupType::Shuntsu, { new NumberTile(NumberType::Bamboo, 3), new NumberTile(NumberType::Bamboo, 4), new NumberTile(NumberType::Bamboo, 5) }, nullptr, false),
-                    TileGroup(TileGroupType::Shuntsu, { new NumberTile(NumberType::Bamboo, 3), new NumberTile(NumberType::Bamboo, 4), new NumberTile(NumberType::Bamboo, 5) }, nullptr, false),
-                    TileGroup(TileGroupType::Shuntsu, { new NumberTile(NumberType::Dots, 6), new NumberTile(NumberType::Dots, 7), new NumberTile(NumberType::Dots, 8) }, nullptr, false),
+                    TileGroup(TileGroupType::Head, { *new NumberTile(NumberType::Cracks, 1), *new NumberTile(NumberType::Cracks, 1) }),
+                    TileGroup(TileGroupType::Shuntsu, { *new NumberTile(NumberType::Bamboo, 3), *new NumberTile(NumberType::Bamboo, 4), *new NumberTile(NumberType::Bamboo, 5) }),
+                    TileGroup(TileGroupType::Shuntsu, { *new NumberTile(NumberType::Bamboo, 3), *new NumberTile(NumberType::Bamboo, 4), *new NumberTile(NumberType::Bamboo, 5) }),
+                    TileGroup(TileGroupType::Shuntsu, { *new NumberTile(NumberType::Dots, 6), *new NumberTile(NumberType::Dots, 7), *new NumberTile(NumberType::Dots, 8) }),
                 },
                 {
-                    new NumberTile(NumberType::Dots, 6),
-                    new NumberTile(NumberType::Dots, 7)
+                    *new NumberTile(NumberType::Dots, 6),
+                    *new NumberTile(NumberType::Dots, 7)
                 }
             };
-            Tile* pickedTile = new NumberTile(NumberType::Dots, 8);
+            TileCRef pickedTile = *new NumberTile(NumberType::Dots, 8);
             bool isMenzen = true;
             bool isRon    = false;
             WindType roundWind = WindType::East;
@@ -394,17 +393,17 @@ namespace Mini
             puts("[  Yaku Test 02  ]");
             ReassembledTileGroup reassembledTileGroup = {
                 { 
-                    TileGroup(TileGroupType::Head, { new NumberTile(NumberType::Cracks, 1), new NumberTile(NumberType::Cracks, 1) }, nullptr, false),
-                    TileGroup(TileGroupType::Shuntsu, { new NumberTile(NumberType::Bamboo, 2), new NumberTile(NumberType::Bamboo, 3), new NumberTile(NumberType::Bamboo, 4) }, nullptr, false),
-                    TileGroup(TileGroupType::Shuntsu, { new NumberTile(NumberType::Bamboo, 1), new NumberTile(NumberType::Bamboo, 2), new NumberTile(NumberType::Bamboo, 3) }, nullptr, false),
-                    TileGroup(TileGroupType::Shuntsu, { new NumberTile(NumberType::Dots, 6), new NumberTile(NumberType::Dots, 7), new NumberTile(NumberType::Dots, 5) }, nullptr, false),
+                    TileGroup(TileGroupType::Head, { *new NumberTile(NumberType::Cracks, 1), *new NumberTile(NumberType::Cracks, 1) }),
+                    TileGroup(TileGroupType::Shuntsu, { *new NumberTile(NumberType::Bamboo, 2), *new NumberTile(NumberType::Bamboo, 3), *new NumberTile(NumberType::Bamboo, 4) }),
+                    TileGroup(TileGroupType::Shuntsu, { *new NumberTile(NumberType::Bamboo, 1), *new NumberTile(NumberType::Bamboo, 2), *new NumberTile(NumberType::Bamboo, 3) }),
+                    TileGroup(TileGroupType::Shuntsu, { *new NumberTile(NumberType::Dots, 6), *new NumberTile(NumberType::Dots, 7), *new NumberTile(NumberType::Dots, 5) }),
                 },
                 {
-                    new NumberTile(NumberType::Dots, 6),
-                    new NumberTile(NumberType::Dots, 7)
+                    *new NumberTile(NumberType::Dots, 6),
+                    *new NumberTile(NumberType::Dots, 7)
                 }
             };
-            Tile* pickedTile = new NumberTile(NumberType::Dots, 5);
+            TileCRef pickedTile = *new NumberTile(NumberType::Dots, 5);
             bool isMenzen = true;
             bool isRon    = false;
             WindType roundWind = WindType::East;
@@ -417,17 +416,17 @@ namespace Mini
             puts("[  Yaku Test 03  ]");
             ReassembledTileGroup reassembledTileGroup = {
                 { 
-                    TileGroup(TileGroupType::Head, { new NumberTile(NumberType::Cracks, 2), new NumberTile(NumberType::Cracks, 2) }, nullptr, false),
-                    TileGroup(TileGroupType::Shuntsu, { new NumberTile(NumberType::Bamboo, 2), new NumberTile(NumberType::Bamboo, 3), new NumberTile(NumberType::Bamboo, 4) }, nullptr, false),
-                    TileGroup(TileGroupType::Shuntsu, { new NumberTile(NumberType::Bamboo, 2), new NumberTile(NumberType::Bamboo, 3), new NumberTile(NumberType::Bamboo, 4) }, nullptr, false),
-                    TileGroup(TileGroupType::Shuntsu, { new NumberTile(NumberType::Dots, 6), new NumberTile(NumberType::Dots, 7), new NumberTile(NumberType::Dots, 8) }, nullptr, false),
+                    TileGroup(TileGroupType::Head, { *new NumberTile(NumberType::Cracks, 2), *new NumberTile(NumberType::Cracks, 2) }),
+                    TileGroup(TileGroupType::Shuntsu, { *new NumberTile(NumberType::Bamboo, 2), *new NumberTile(NumberType::Bamboo, 3), *new NumberTile(NumberType::Bamboo, 4) }),
+                    TileGroup(TileGroupType::Shuntsu, { *new NumberTile(NumberType::Bamboo, 2), *new NumberTile(NumberType::Bamboo, 3), *new NumberTile(NumberType::Bamboo, 4) }),
+                    TileGroup(TileGroupType::Shuntsu, { *new NumberTile(NumberType::Dots, 6), *new NumberTile(NumberType::Dots, 7), *new NumberTile(NumberType::Dots, 8) }),
                 },
                 {
-                    new NumberTile(NumberType::Dots, 6),
-                    new NumberTile(NumberType::Dots, 7)
+                    *new NumberTile(NumberType::Dots, 6),
+                    *new NumberTile(NumberType::Dots, 7)
                 }
             };
-            Tile* pickedTile = new NumberTile(NumberType::Dots, 5);
+            TileCRef pickedTile = *new NumberTile(NumberType::Dots, 5);
             bool isMenzen = true;
             bool isRon    = true;
             WindType roundWind = WindType::East;
@@ -440,16 +439,16 @@ namespace Mini
             puts("[  Yaku Test 04  ]");
             ReassembledTileGroup reassembledTileGroup = {
                 { 
-                    TileGroup(TileGroupType::Shuntsu, { new NumberTile(NumberType::Cracks, 2), new NumberTile(NumberType::Cracks, 3), new NumberTile(NumberType::Cracks, 4) }, nullptr, false),
-                    TileGroup(TileGroupType::Shuntsu, { new NumberTile(NumberType::Bamboo, 2), new NumberTile(NumberType::Bamboo, 3), new NumberTile(NumberType::Bamboo, 4) }, nullptr, false),
-                    TileGroup(TileGroupType::Shuntsu, { new NumberTile(NumberType::Bamboo, 2), new NumberTile(NumberType::Bamboo, 3), new NumberTile(NumberType::Bamboo, 4) }, nullptr, false),
-                    TileGroup(TileGroupType::Shuntsu, { new NumberTile(NumberType::Dots, 6), new NumberTile(NumberType::Dots, 7), new NumberTile(NumberType::Dots, 8) }, nullptr, false),
+                    TileGroup(TileGroupType::Shuntsu, { *new NumberTile(NumberType::Cracks, 2), *new NumberTile(NumberType::Cracks, 3), *new NumberTile(NumberType::Cracks, 4) }),
+                    TileGroup(TileGroupType::Shuntsu, { *new NumberTile(NumberType::Bamboo, 2), *new NumberTile(NumberType::Bamboo, 3), *new NumberTile(NumberType::Bamboo, 4) }),
+                    TileGroup(TileGroupType::Shuntsu, { *new NumberTile(NumberType::Bamboo, 2), *new NumberTile(NumberType::Bamboo, 3), *new NumberTile(NumberType::Bamboo, 4) }),
+                    TileGroup(TileGroupType::Shuntsu, { *new NumberTile(NumberType::Dots, 6), *new NumberTile(NumberType::Dots, 7), *new NumberTile(NumberType::Dots, 8) }),
                 },
                 {
-                    new NumberTile(NumberType::Dots, 7)
+                    *new NumberTile(NumberType::Dots, 7)
                 }
             };
-            Tile* pickedTile = new NumberTile(NumberType::Dots, 7);
+            TileCRef pickedTile = *new NumberTile(NumberType::Dots, 7);
             bool isMenzen = true;
             bool isRon    = true;
             WindType roundWind = WindType::East;
@@ -462,16 +461,16 @@ namespace Mini
             puts("[  Yaku Test 05  ]");
             ReassembledTileGroup reassembledTileGroup = {
                 { 
-                    TileGroup(TileGroupType::Shuntsu, { new NumberTile(NumberType::Cracks, 2), new NumberTile(NumberType::Cracks, 3), new NumberTile(NumberType::Cracks, 4) }, nullptr, false),
-                    TileGroup(TileGroupType::Shuntsu, { new NumberTile(NumberType::Cracks, 2), new NumberTile(NumberType::Cracks, 3), new NumberTile(NumberType::Cracks, 4) }, nullptr, false),
-                    TileGroup(TileGroupType::Shuntsu, { new NumberTile(NumberType::Bamboo, 3), new NumberTile(NumberType::Bamboo, 4), new NumberTile(NumberType::Bamboo, 5) }, nullptr, false),
-                    TileGroup(TileGroupType::Shuntsu, { new NumberTile(NumberType::Bamboo, 3), new NumberTile(NumberType::Bamboo, 4), new NumberTile(NumberType::Bamboo, 5) }, nullptr, false),
+                    TileGroup(TileGroupType::Shuntsu, { *new NumberTile(NumberType::Cracks, 2), *new NumberTile(NumberType::Cracks, 3), *new NumberTile(NumberType::Cracks, 4) }),
+                    TileGroup(TileGroupType::Shuntsu, { *new NumberTile(NumberType::Cracks, 2), *new NumberTile(NumberType::Cracks, 3), *new NumberTile(NumberType::Cracks, 4) }),
+                    TileGroup(TileGroupType::Shuntsu, { *new NumberTile(NumberType::Bamboo, 3), *new NumberTile(NumberType::Bamboo, 4), *new NumberTile(NumberType::Bamboo, 5) }),
+                    TileGroup(TileGroupType::Shuntsu, { *new NumberTile(NumberType::Bamboo, 3), *new NumberTile(NumberType::Bamboo, 4), *new NumberTile(NumberType::Bamboo, 5) }),
                 },
                 {
-                    new NumberTile(NumberType::Dots, 7)
+                    *new NumberTile(NumberType::Dots, 7)
                 }
             };
-            Tile* pickedTile = new NumberTile(NumberType::Dots, 7);
+            TileCRef pickedTile = *new NumberTile(NumberType::Dots, 7);
             bool isMenzen = true;
             bool isRon    = true;
             WindType roundWind = WindType::East;
@@ -484,16 +483,16 @@ namespace Mini
             puts("[  Yaku Test 06  ]");
             ReassembledTileGroup reassembledTileGroup = {
                 { 
-                    TileGroup(TileGroupType::Shuntsu, { new NumberTile(NumberType::Cracks, 1), new NumberTile(NumberType::Cracks, 2), new NumberTile(NumberType::Cracks, 3) }, nullptr, false),
-                    TileGroup(TileGroupType::Shuntsu, { new NumberTile(NumberType::Cracks, 4), new NumberTile(NumberType::Cracks, 5), new NumberTile(NumberType::Cracks, 6) }, nullptr, false),
-                    TileGroup(TileGroupType::Shuntsu, { new NumberTile(NumberType::Cracks, 7), new NumberTile(NumberType::Cracks, 8), new NumberTile(NumberType::Cracks, 9) }, nullptr, false),
-                    TileGroup(TileGroupType::Shuntsu, { new NumberTile(NumberType::Bamboo, 3), new NumberTile(NumberType::Bamboo, 4), new NumberTile(NumberType::Bamboo, 5) }, nullptr, false),
+                    TileGroup(TileGroupType::Shuntsu, { *new NumberTile(NumberType::Cracks, 1), *new NumberTile(NumberType::Cracks, 2), *new NumberTile(NumberType::Cracks, 3) }),
+                    TileGroup(TileGroupType::Shuntsu, { *new NumberTile(NumberType::Cracks, 4), *new NumberTile(NumberType::Cracks, 5), *new NumberTile(NumberType::Cracks, 6) }),
+                    TileGroup(TileGroupType::Shuntsu, { *new NumberTile(NumberType::Cracks, 7), *new NumberTile(NumberType::Cracks, 8), *new NumberTile(NumberType::Cracks, 9) }),
+                    TileGroup(TileGroupType::Shuntsu, { *new NumberTile(NumberType::Bamboo, 3), *new NumberTile(NumberType::Bamboo, 4), *new NumberTile(NumberType::Bamboo, 5) }),
                 },
                 {
-                    new NumberTile(NumberType::Dots, 7)
+                    *new NumberTile(NumberType::Dots, 7)
                 }
             };
-            Tile* pickedTile = new NumberTile(NumberType::Dots, 7);
+            TileCRef pickedTile = *new NumberTile(NumberType::Dots, 7);
             bool isMenzen = true;
             bool isRon    = true;
             WindType roundWind = WindType::East;
@@ -506,17 +505,17 @@ namespace Mini
             puts("[  Yaku Test 07  ]");
             ReassembledTileGroup reassembledTileGroup = {
                 { 
-                    TileGroup(TileGroupType::Head, { new NumberTile(NumberType::Cracks, 1), new NumberTile(NumberType::Cracks, 1) }, nullptr, false),
-                    TileGroup(TileGroupType::Shuntsu, { new NumberTile(NumberType::Cracks, 2), new NumberTile(NumberType::Cracks, 3), new NumberTile(NumberType::Cracks, 4) }, nullptr, false),
-                    TileGroup(TileGroupType::Shuntsu, { new NumberTile(NumberType::Bamboo, 4), new NumberTile(NumberType::Bamboo, 5), new NumberTile(NumberType::Bamboo, 6) }, nullptr, false),
-                    TileGroup(TileGroupType::Shuntsu, { new NumberTile(NumberType::Bamboo, 7), new NumberTile(NumberType::Bamboo, 8), new NumberTile(NumberType::Bamboo, 9) }, nullptr, false),
+                    TileGroup(TileGroupType::Head, { *new NumberTile(NumberType::Cracks, 1), *new NumberTile(NumberType::Cracks, 1) }),
+                    TileGroup(TileGroupType::Shuntsu, { *new NumberTile(NumberType::Cracks, 2), *new NumberTile(NumberType::Cracks, 3), *new NumberTile(NumberType::Cracks, 4) }),
+                    TileGroup(TileGroupType::Shuntsu, { *new NumberTile(NumberType::Bamboo, 4), *new NumberTile(NumberType::Bamboo, 5), *new NumberTile(NumberType::Bamboo, 6) }),
+                    TileGroup(TileGroupType::Shuntsu, { *new NumberTile(NumberType::Bamboo, 7), *new NumberTile(NumberType::Bamboo, 8), *new NumberTile(NumberType::Bamboo, 9) }),
                 },
                 {
-                    new NumberTile(NumberType::Bamboo, 1),
-                    new NumberTile(NumberType::Bamboo, 3)
+                    *new NumberTile(NumberType::Bamboo, 1),
+                    *new NumberTile(NumberType::Bamboo, 3)
                 }
             };
-            Tile* pickedTile = new NumberTile(NumberType::Bamboo, 2);
+            TileCRef pickedTile = *new NumberTile(NumberType::Bamboo, 2);
             bool isMenzen = true;
             bool isRon    = true;
             WindType roundWind = WindType::East;
@@ -547,17 +546,17 @@ namespace Mini
             puts("[  Yaku Test 01  ]");
             ReassembledTileGroup reassembledTileGroup = {
                 { 
-                    TileGroup(TileGroupType::Head, { new NumberTile(NumberType::Cracks, 2), new NumberTile(NumberType::Cracks, 2) }, nullptr, false),
-                    TileGroup(TileGroupType::Shuntsu, { new NumberTile(NumberType::Bamboo, 2), new NumberTile(NumberType::Bamboo, 3), new NumberTile(NumberType::Bamboo, 4) }, nullptr, false),
-                    TileGroup(TileGroupType::Shuntsu, { new NumberTile(NumberType::Bamboo, 2), new NumberTile(NumberType::Bamboo, 3), new NumberTile(NumberType::Bamboo, 4) }, nullptr, false),
-                    TileGroup(TileGroupType::Shuntsu, { new NumberTile(NumberType::Dots, 2), new NumberTile(NumberType::Dots, 3), new NumberTile(NumberType::Dots, 4) }, nullptr, false),
+                    TileGroup(TileGroupType::Head, { *new NumberTile(NumberType::Cracks, 2), *new NumberTile(NumberType::Cracks, 2) }),
+                    TileGroup(TileGroupType::Shuntsu, { *new NumberTile(NumberType::Bamboo, 2), *new NumberTile(NumberType::Bamboo, 3), *new NumberTile(NumberType::Bamboo, 4) }),
+                    TileGroup(TileGroupType::Shuntsu, { *new NumberTile(NumberType::Bamboo, 2), *new NumberTile(NumberType::Bamboo, 3), *new NumberTile(NumberType::Bamboo, 4) }),
+                    TileGroup(TileGroupType::Shuntsu, { *new NumberTile(NumberType::Dots, 2), *new NumberTile(NumberType::Dots, 3), *new NumberTile(NumberType::Dots, 4) }),
                 },
                 {
-                    new NumberTile(NumberType::Cracks, 3),
-                    new NumberTile(NumberType::Cracks, 2)
+                    *new NumberTile(NumberType::Cracks, 3),
+                    *new NumberTile(NumberType::Cracks, 2)
                 }
             };
-            Tile* pickedTile = new NumberTile(NumberType::Cracks, 4);
+            TileCRef pickedTile = *new NumberTile(NumberType::Cracks, 4);
             bool isMenzen = true;
             bool isRon    = false;
             WindType roundWind = WindType::East;
@@ -570,17 +569,17 @@ namespace Mini
             puts("[  Yaku Test 02 ]");
             ReassembledTileGroup reassembledTileGroup = {
                 { 
-                    TileGroup(TileGroupType::Head, { new NumberTile(NumberType::Cracks, 2), new NumberTile(NumberType::Cracks, 2) }, nullptr, false),
-                    TileGroup(TileGroupType::Shuntsu, { new NumberTile(NumberType::Bamboo, 2), new NumberTile(NumberType::Bamboo, 3), new NumberTile(NumberType::Bamboo, 4) }, nullptr, false),
-                    TileGroup(TileGroupType::Shuntsu, { new NumberTile(NumberType::Bamboo, 2), new NumberTile(NumberType::Bamboo, 3), new NumberTile(NumberType::Bamboo, 4) }, nullptr, false),
-                    TileGroup(TileGroupType::Shuntsu, { new NumberTile(NumberType::Dots, 2), new NumberTile(NumberType::Dots, 3), new NumberTile(NumberType::Dots, 4) }, nullptr, false),
+                    TileGroup(TileGroupType::Head, { *new NumberTile(NumberType::Cracks, 2), *new NumberTile(NumberType::Cracks, 2) }),
+                    TileGroup(TileGroupType::Shuntsu, { *new NumberTile(NumberType::Bamboo, 2), *new NumberTile(NumberType::Bamboo, 3), *new NumberTile(NumberType::Bamboo, 4) }),
+                    TileGroup(TileGroupType::Shuntsu, { *new NumberTile(NumberType::Bamboo, 2), *new NumberTile(NumberType::Bamboo, 3), *new NumberTile(NumberType::Bamboo, 4) }),
+                    TileGroup(TileGroupType::Shuntsu, { *new NumberTile(NumberType::Dots, 2), *new NumberTile(NumberType::Dots, 3), *new NumberTile(NumberType::Dots, 4) }),
                 },
                 {
-                    new NumberTile(NumberType::Cracks, 4),
-                    new NumberTile(NumberType::Cracks, 2)
+                    *new NumberTile(NumberType::Cracks, 4),
+                    *new NumberTile(NumberType::Cracks, 2)
                 }
             };
-            Tile* pickedTile = new NumberTile(NumberType::Cracks, 3);
+            TileCRef pickedTile = *new NumberTile(NumberType::Cracks, 3);
             bool isMenzen = true;
             bool isRon    = false;
             WindType roundWind = WindType::East;
@@ -593,17 +592,17 @@ namespace Mini
             puts("[  Yaku Test 03 ]");
             ReassembledTileGroup reassembledTileGroup = {
                 { 
-                    TileGroup(TileGroupType::Head, { new NumberTile(NumberType::Cracks, 2), new NumberTile(NumberType::Cracks, 2) }, nullptr, false),
-                    TileGroup(TileGroupType::Shuntsu, { new NumberTile(NumberType::Bamboo, 2), new NumberTile(NumberType::Bamboo, 3), new NumberTile(NumberType::Bamboo, 4) }, nullptr, false),
-                    TileGroup(TileGroupType::Shuntsu, { new NumberTile(NumberType::Bamboo, 2), new NumberTile(NumberType::Bamboo, 3), new NumberTile(NumberType::Bamboo, 4) }, nullptr, false),
-                    TileGroup(TileGroupType::Shuntsu, { new NumberTile(NumberType::Dots, 2), new NumberTile(NumberType::Dots, 3), new NumberTile(NumberType::Dots, 4) }, nullptr, false),
+                    TileGroup(TileGroupType::Head, { *new NumberTile(NumberType::Cracks, 2), *new NumberTile(NumberType::Cracks, 2) }),
+                    TileGroup(TileGroupType::Shuntsu, { *new NumberTile(NumberType::Bamboo, 2), *new NumberTile(NumberType::Bamboo, 3), *new NumberTile(NumberType::Bamboo, 4) }),
+                    TileGroup(TileGroupType::Shuntsu, { *new NumberTile(NumberType::Bamboo, 2), *new NumberTile(NumberType::Bamboo, 3), *new NumberTile(NumberType::Bamboo, 4) }),
+                    TileGroup(TileGroupType::Shuntsu, { *new NumberTile(NumberType::Dots, 2), *new NumberTile(NumberType::Dots, 3), *new NumberTile(NumberType::Dots, 4) }),
                 },
                 {
-                    new NumberTile(NumberType::Cracks, 5),
-                    new NumberTile(NumberType::Cracks, 6)
+                    *new NumberTile(NumberType::Cracks, 5),
+                    *new NumberTile(NumberType::Cracks, 6)
                 }
             };
-            Tile* pickedTile = new NumberTile(NumberType::Cracks, 4);
+            TileCRef pickedTile = *new NumberTile(NumberType::Cracks, 4);
             bool isMenzen = true;
             bool isRon    = false;
             WindType roundWind = WindType::East;
@@ -616,17 +615,17 @@ namespace Mini
             puts("[  Yaku Test 04 ]");
             ReassembledTileGroup reassembledTileGroup = {
                 { 
-                    TileGroup(TileGroupType::Head, { new NumberTile(NumberType::Cracks, 5), new NumberTile(NumberType::Cracks, 5) }, nullptr, false),
-                    TileGroup(TileGroupType::Koutsu, { new NumberTile(NumberType::Cracks, 2), new NumberTile(NumberType::Cracks, 2), new NumberTile(NumberType::Cracks, 2) }, nullptr, false),
-                    TileGroup(TileGroupType::Koutsu, { new NumberTile(NumberType::Bamboo, 2), new NumberTile(NumberType::Bamboo, 2), new NumberTile(NumberType::Bamboo, 2) }, nullptr, false),
-                    TileGroup(TileGroupType::Shuntsu, { new NumberTile(NumberType::Dots, 1), new NumberTile(NumberType::Dots, 2), new NumberTile(NumberType::Dots, 3) }, nullptr, false),
+                    TileGroup(TileGroupType::Head, { *new NumberTile(NumberType::Cracks, 5), *new NumberTile(NumberType::Cracks, 5) }),
+                    TileGroup(TileGroupType::Koutsu, { *new NumberTile(NumberType::Cracks, 2), *new NumberTile(NumberType::Cracks, 2), *new NumberTile(NumberType::Cracks, 2) }),
+                    TileGroup(TileGroupType::Koutsu, { *new NumberTile(NumberType::Bamboo, 2), *new NumberTile(NumberType::Bamboo, 2), *new NumberTile(NumberType::Bamboo, 2) }),
+                    TileGroup(TileGroupType::Shuntsu, { *new NumberTile(NumberType::Dots, 1), *new NumberTile(NumberType::Dots, 2), *new NumberTile(NumberType::Dots, 3) }),
                 },
                 {
-                    new NumberTile(NumberType::Dots, 2),
-                    new NumberTile(NumberType::Dots, 2)
+                    *new NumberTile(NumberType::Dots, 2),
+                    *new NumberTile(NumberType::Dots, 2)
                 }
             };
-            Tile* pickedTile = new NumberTile(NumberType::Dots, 2);
+            TileCRef pickedTile = *new NumberTile(NumberType::Dots, 2);
             bool isMenzen = true;
             bool isRon    = false;
             WindType roundWind = WindType::East;
@@ -639,16 +638,16 @@ namespace Mini
             puts("[  Yaku Test 05 ]");
             ReassembledTileGroup reassembledTileGroup = {
                 { 
-                    TileGroup(TileGroupType::Koutsu, { new NumberTile(NumberType::Cracks, 4), new NumberTile(NumberType::Cracks, 4), new NumberTile(NumberType::Cracks, 4) }, nullptr, false),
-                    TileGroup(TileGroupType::Koutsu, { new NumberTile(NumberType::Bamboo, 4), new NumberTile(NumberType::Bamboo, 4), new NumberTile(NumberType::Bamboo, 4) }, nullptr, false),
-                    TileGroup(TileGroupType::Shuntsu, { new NumberTile(NumberType::Bamboo, 6), new NumberTile(NumberType::Bamboo, 7), new NumberTile(NumberType::Bamboo, 8) }, nullptr, false),
-                    TileGroup(TileGroupType::Kangtsu, { new NumberTile(NumberType::Dots, 4), new NumberTile(NumberType::Dots, 4), new NumberTile(NumberType::Dots, 4), new NumberTile(NumberType::Dots, 4) }, nullptr, false),
+                    TileGroup(TileGroupType::Koutsu, { *new NumberTile(NumberType::Cracks, 4), *new NumberTile(NumberType::Cracks, 4), *new NumberTile(NumberType::Cracks, 4) }),
+                    TileGroup(TileGroupType::Koutsu, { *new NumberTile(NumberType::Bamboo, 4), *new NumberTile(NumberType::Bamboo, 4), *new NumberTile(NumberType::Bamboo, 4) }),
+                    TileGroup(TileGroupType::Shuntsu, { *new NumberTile(NumberType::Bamboo, 6), *new NumberTile(NumberType::Bamboo, 7), *new NumberTile(NumberType::Bamboo, 8) }),
+                    TileGroup(TileGroupType::Kangtsu, { *new NumberTile(NumberType::Dots, 4), *new NumberTile(NumberType::Dots, 4), *new NumberTile(NumberType::Dots, 4), *new NumberTile(NumberType::Dots, 4) }),
                 },
                 {
-                    new NumberTile(NumberType::Cracks, 5)
+                    *new NumberTile(NumberType::Cracks, 5)
                 }
             };
-            Tile* pickedTile = new NumberTile(NumberType::Cracks, 5);
+            TileCRef pickedTile = *new NumberTile(NumberType::Cracks, 5);
             bool isMenzen = true;
             bool isRon    = false;
             WindType roundWind = WindType::East;
@@ -683,17 +682,17 @@ namespace Mini
             puts("[  Yaku Test 01  ]");
             ReassembledTileGroup reassembledTileGroup = {
                 { 
-                    TileGroup(TileGroupType::Head, { new WindTile(WindType::South), new WindTile(WindType::South) }, nullptr, false),
-                    TileGroup(TileGroupType::Shuntsu, { new NumberTile(NumberType::Bamboo, 1), new NumberTile(NumberType::Bamboo, 2), new NumberTile(NumberType::Bamboo, 3) }, nullptr, false),
-                    TileGroup(TileGroupType::Shuntsu, { new NumberTile(NumberType::Dots, 7), new NumberTile(NumberType::Dots, 8), new NumberTile(NumberType::Dots, 9) }, nullptr, false),
-                    TileGroup(TileGroupType::Koutsu, { new DragonTile(DragonType::White), new DragonTile(DragonType::White), new DragonTile(DragonType::White) }, nullptr, false),
+                    TileGroup(TileGroupType::Head, { *new WindTile(WindType::South), *new WindTile(WindType::South) }),
+                    TileGroup(TileGroupType::Shuntsu, { *new NumberTile(NumberType::Bamboo, 1), *new NumberTile(NumberType::Bamboo, 2), *new NumberTile(NumberType::Bamboo, 3) }),
+                    TileGroup(TileGroupType::Shuntsu, { *new NumberTile(NumberType::Dots, 7), *new NumberTile(NumberType::Dots, 8), *new NumberTile(NumberType::Dots, 9) }),
+                    TileGroup(TileGroupType::Koutsu, { *new DragonTile(DragonType::White), *new DragonTile(DragonType::White), *new DragonTile(DragonType::White) }),
                 },
                 {
-                    new WindTile(WindType::East),
-                    new WindTile(WindType::East)
+                    *new WindTile(WindType::East),
+                    *new WindTile(WindType::East)
                 }
             };
-            Tile* pickedTile = new WindTile(WindType::East);
+            TileCRef pickedTile = *new WindTile(WindType::East);
             bool isMenzen = true;
             bool isRon    = true;
             WindType roundWind = WindType::East;
@@ -706,17 +705,17 @@ namespace Mini
             puts("[  Yaku Test 02  ]");
             ReassembledTileGroup reassembledTileGroup = {
                 { 
-                    TileGroup(TileGroupType::Head, { new WindTile(WindType::South), new WindTile(WindType::South) }, nullptr, false),
-                    TileGroup(TileGroupType::Shuntsu, { new NumberTile(NumberType::Bamboo, 1), new NumberTile(NumberType::Bamboo, 2), new NumberTile(NumberType::Bamboo, 3) }, nullptr, false),
-                    TileGroup(TileGroupType::Shuntsu, { new NumberTile(NumberType::Dots, 7), new NumberTile(NumberType::Dots, 8), new NumberTile(NumberType::Dots, 9) }, nullptr, false),
-                    TileGroup(TileGroupType::Koutsu, { new DragonTile(DragonType::White), new DragonTile(DragonType::White), new DragonTile(DragonType::White) }, nullptr, false),
+                    TileGroup(TileGroupType::Head, { *new WindTile(WindType::South), *new WindTile(WindType::South) }),
+                    TileGroup(TileGroupType::Shuntsu, { *new NumberTile(NumberType::Bamboo, 1), *new NumberTile(NumberType::Bamboo, 2), *new NumberTile(NumberType::Bamboo, 3) }),
+                    TileGroup(TileGroupType::Shuntsu, { *new NumberTile(NumberType::Dots, 7), *new NumberTile(NumberType::Dots, 8), *new NumberTile(NumberType::Dots, 9) }),
+                    TileGroup(TileGroupType::Koutsu, { *new DragonTile(DragonType::White), *new DragonTile(DragonType::White), *new DragonTile(DragonType::White) }),
                 },
                 {
-                    new WindTile(WindType::East),
-                    new WindTile(WindType::East)
+                    *new WindTile(WindType::East),
+                    *new WindTile(WindType::East)
                 }
             };
-            Tile* pickedTile = new WindTile(WindType::East);
+            TileCRef pickedTile = *new WindTile(WindType::East);
             bool isMenzen = false;
             bool isRon    = false;
             WindType roundWind = WindType::East;
@@ -729,17 +728,17 @@ namespace Mini
             puts("[  Yaku Test 03  ]");
             ReassembledTileGroup reassembledTileGroup = {
                 { 
-                    TileGroup(TileGroupType::Head, { new NumberTile(NumberType::Dots, 1), new NumberTile(NumberType::Dots, 1) }, nullptr, false),
-                    TileGroup(TileGroupType::Shuntsu, { new NumberTile(NumberType::Cracks, 1), new NumberTile(NumberType::Cracks, 2), new NumberTile(NumberType::Cracks, 3) }, nullptr, false),
-                    TileGroup(TileGroupType::Shuntsu, { new NumberTile(NumberType::Bamboo, 1), new NumberTile(NumberType::Bamboo, 2), new NumberTile(NumberType::Bamboo, 3) }, nullptr, false),
-                    TileGroup(TileGroupType::Shuntsu, { new NumberTile(NumberType::Dots, 1), new NumberTile(NumberType::Dots, 2), new NumberTile(NumberType::Dots, 3) }, nullptr, false),
+                    TileGroup(TileGroupType::Head, { *new NumberTile(NumberType::Dots, 1), *new NumberTile(NumberType::Dots, 1) }),
+                    TileGroup(TileGroupType::Shuntsu, { *new NumberTile(NumberType::Cracks, 1), *new NumberTile(NumberType::Cracks, 2), *new NumberTile(NumberType::Cracks, 3) }),
+                    TileGroup(TileGroupType::Shuntsu, { *new NumberTile(NumberType::Bamboo, 1), *new NumberTile(NumberType::Bamboo, 2), *new NumberTile(NumberType::Bamboo, 3) }),
+                    TileGroup(TileGroupType::Shuntsu, { *new NumberTile(NumberType::Dots, 1), *new NumberTile(NumberType::Dots, 2), *new NumberTile(NumberType::Dots, 3) }),
                 },
                 {
-                    new NumberTile(NumberType::Dots, 1),
-                    new NumberTile(NumberType::Dots, 2)
+                    *new NumberTile(NumberType::Dots, 1),
+                    *new NumberTile(NumberType::Dots, 2)
                 }
             };
-            Tile* pickedTile = new NumberTile(NumberType::Dots, 3);
+            TileCRef pickedTile = *new NumberTile(NumberType::Dots, 3);
             bool isMenzen = false;
             bool isRon    = false;
             WindType roundWind = WindType::East;
@@ -752,17 +751,17 @@ namespace Mini
             puts("[  Yaku Test 04  ]");
             ReassembledTileGroup reassembledTileGroup = {
                 { 
-                    TileGroup(TileGroupType::Head, { new WindTile(WindType::South), new WindTile(WindType::South) }, nullptr, false),
-                    TileGroup(TileGroupType::Koutsu, { new NumberTile(NumberType::Bamboo, 1), new NumberTile(NumberType::Bamboo, 1), new NumberTile(NumberType::Bamboo, 1) }, nullptr, false),
-                    TileGroup(TileGroupType::Kangtsu, { new NumberTile(NumberType::Dots, 9), new NumberTile(NumberType::Dots, 9), new NumberTile(NumberType::Dots, 9), new NumberTile(NumberType::Dots, 9) }, nullptr, false),
-                    TileGroup(TileGroupType::Koutsu, { new DragonTile(DragonType::White), new DragonTile(DragonType::White), new DragonTile(DragonType::White) }, nullptr, false),
+                    TileGroup(TileGroupType::Head, { *new WindTile(WindType::South), *new WindTile(WindType::South) }),
+                    TileGroup(TileGroupType::Koutsu, { *new NumberTile(NumberType::Bamboo, 1), *new NumberTile(NumberType::Bamboo, 1), *new NumberTile(NumberType::Bamboo, 1) }),
+                    TileGroup(TileGroupType::Kangtsu, { *new NumberTile(NumberType::Dots, 9), *new NumberTile(NumberType::Dots, 9), *new NumberTile(NumberType::Dots, 9), *new NumberTile(NumberType::Dots, 9) }),
+                    TileGroup(TileGroupType::Koutsu, { *new DragonTile(DragonType::White), *new DragonTile(DragonType::White), *new DragonTile(DragonType::White) }),
                 },
                 {
-                    new WindTile(WindType::East),
-                    new WindTile(WindType::East)
+                    *new WindTile(WindType::East),
+                    *new WindTile(WindType::East)
                 }
             };
-            Tile* pickedTile = new WindTile(WindType::East);
+            TileCRef pickedTile = *new WindTile(WindType::East);
             bool isMenzen = false;
             bool isRon    = false;
             WindType roundWind = WindType::East;
@@ -775,17 +774,17 @@ namespace Mini
             puts("[  Yaku Test 05  ]");
             ReassembledTileGroup reassembledTileGroup = {
                 { 
-                    TileGroup(TileGroupType::Head, { new NumberTile(NumberType::Cracks, 1), new NumberTile(NumberType::Cracks, 1) }, nullptr, false),
-                    TileGroup(TileGroupType::Koutsu, { new NumberTile(NumberType::Cracks, 9), new NumberTile(NumberType::Cracks, 9), new NumberTile(NumberType::Cracks, 9) }, nullptr, false),
-                    TileGroup(TileGroupType::Koutsu, { new NumberTile(NumberType::Bamboo, 9), new NumberTile(NumberType::Bamboo, 9), new NumberTile(NumberType::Bamboo, 9) }, nullptr, false),
-                    TileGroup(TileGroupType::Koutsu, { new NumberTile(NumberType::Dots, 1), new NumberTile(NumberType::Dots, 1), new NumberTile(NumberType::Dots, 1) }, nullptr, false),
+                    TileGroup(TileGroupType::Head, { *new NumberTile(NumberType::Cracks, 1), *new NumberTile(NumberType::Cracks, 1) }),
+                    TileGroup(TileGroupType::Koutsu, { *new NumberTile(NumberType::Cracks, 9), *new NumberTile(NumberType::Cracks, 9), *new NumberTile(NumberType::Cracks, 9) }),
+                    TileGroup(TileGroupType::Koutsu, { *new NumberTile(NumberType::Bamboo, 9), *new NumberTile(NumberType::Bamboo, 9), *new NumberTile(NumberType::Bamboo, 9) }),
+                    TileGroup(TileGroupType::Koutsu, { *new NumberTile(NumberType::Dots, 1), *new NumberTile(NumberType::Dots, 1), *new NumberTile(NumberType::Dots, 1) }),
                 },
                 {
-                    new NumberTile(NumberType::Dots, 9),
-                    new NumberTile(NumberType::Dots, 9)
+                    *new NumberTile(NumberType::Dots, 9),
+                    *new NumberTile(NumberType::Dots, 9)
                 }
             };
-            Tile* pickedTile = new NumberTile(NumberType::Dots, 9);
+            TileCRef pickedTile = *new NumberTile(NumberType::Dots, 9);
             bool isMenzen = false;
             bool isRon    = false;
             WindType roundWind = WindType::East;
@@ -826,17 +825,17 @@ namespace Mini
             puts("[  Yaku Test 01  ]");
             ReassembledTileGroup reassembledTileGroup = {
                 { 
-                    TileGroup(TileGroupType::Head, { new WindTile(WindType::South), new WindTile(WindType::South) }, nullptr, false),
-                    TileGroup(TileGroupType::Koutsu, { new WindTile(WindType::North), new WindTile(WindType::North) }, new WindTile(WindType::North), true),
-                    TileGroup(TileGroupType::Koutsu, { new DragonTile(DragonType::Red), new DragonTile(DragonType::Red), new DragonTile(DragonType::Red) }, nullptr, false),
-                    TileGroup(TileGroupType::Koutsu, { new DragonTile(DragonType::White), new DragonTile(DragonType::White), new DragonTile(DragonType::White) }, nullptr, false),
+                    TileGroup(TileGroupType::Head, { *new WindTile(WindType::South), *new WindTile(WindType::South) }),
+                    TileGroup(TileGroupType::Koutsu, { *new WindTile(WindType::North), *new WindTile(WindType::North) }, *new WindTile(WindType::North), true),
+                    TileGroup(TileGroupType::Koutsu, { *new DragonTile(DragonType::Red), *new DragonTile(DragonType::Red), *new DragonTile(DragonType::Red) }),
+                    TileGroup(TileGroupType::Koutsu, { *new DragonTile(DragonType::White), *new DragonTile(DragonType::White), *new DragonTile(DragonType::White) }),
                 },
                 {
-                    new WindTile(WindType::East),
-                    new WindTile(WindType::East)
+                    *new WindTile(WindType::East),
+                    *new WindTile(WindType::East)
                 }
             };
-            Tile* pickedTile = new WindTile(WindType::East);
+            TileCRef pickedTile = *new WindTile(WindType::East);
             bool isMenzen = false;
             bool isRon    = true;
             WindType roundWind = WindType::East;
@@ -849,17 +848,17 @@ namespace Mini
             puts("[  Yaku Test 02  ]");
             ReassembledTileGroup reassembledTileGroup = {
                 { 
-                    TileGroup(TileGroupType::Head, { new WindTile(WindType::South), new WindTile(WindType::South) }, nullptr, false),
-                    TileGroup(TileGroupType::Shuntsu, { new NumberTile(NumberType::Bamboo, 1), new NumberTile(NumberType::Bamboo, 2)},  new NumberTile(NumberType::Bamboo, 3), true),
-                    TileGroup(TileGroupType::Koutsu, { new DragonTile(DragonType::Red), new DragonTile(DragonType::Red), new DragonTile(DragonType::Red) }, nullptr, false),
-                    TileGroup(TileGroupType::Koutsu, { new DragonTile(DragonType::White), new DragonTile(DragonType::White), new DragonTile(DragonType::White) }, nullptr, false),
+                    TileGroup(TileGroupType::Head, { *new WindTile(WindType::South), *new WindTile(WindType::South) }),
+                    TileGroup(TileGroupType::Shuntsu, { *new NumberTile(NumberType::Bamboo, 1), *new NumberTile(NumberType::Bamboo, 2)},  *new NumberTile(NumberType::Bamboo, 3), true),
+                    TileGroup(TileGroupType::Koutsu, { *new DragonTile(DragonType::Red), *new DragonTile(DragonType::Red), *new DragonTile(DragonType::Red) }),
+                    TileGroup(TileGroupType::Koutsu, { *new DragonTile(DragonType::White), *new DragonTile(DragonType::White), *new DragonTile(DragonType::White) }),
                 },
                 {
-                    new WindTile(WindType::East),
-                    new WindTile(WindType::East)
+                    *new WindTile(WindType::East),
+                    *new WindTile(WindType::East)
                 }
             };
-            Tile* pickedTile = new WindTile(WindType::East);
+            TileCRef pickedTile = *new WindTile(WindType::East);
             bool isMenzen = false;
             bool isRon    = true;
             WindType roundWind = WindType::East;
@@ -872,16 +871,16 @@ namespace Mini
             puts("[  Yaku Test 03  ]");
             ReassembledTileGroup reassembledTileGroup = {
                 { 
-                    TileGroup(TileGroupType::Shuntsu, { new NumberTile(NumberType::Bamboo, 1), new NumberTile(NumberType::Bamboo, 2), new NumberTile(NumberType::Bamboo, 3)}, nullptr, false),
-                    TileGroup(TileGroupType::Shuntsu, { new NumberTile(NumberType::Bamboo, 1), new NumberTile(NumberType::Bamboo, 2), new NumberTile(NumberType::Bamboo, 3)}, nullptr, false),
-                    TileGroup(TileGroupType::Koutsu, { new NumberTile(NumberType::Bamboo, 5), new NumberTile(NumberType::Bamboo, 5), new NumberTile(NumberType::Bamboo, 5)}, nullptr, false),
-                    TileGroup(TileGroupType::Shuntsu, { new NumberTile(NumberType::Bamboo, 7), new NumberTile(NumberType::Bamboo, 8), new NumberTile(NumberType::Bamboo, 9)}, nullptr, false),
+                    TileGroup(TileGroupType::Shuntsu, { *new NumberTile(NumberType::Bamboo, 1), *new NumberTile(NumberType::Bamboo, 2), *new NumberTile(NumberType::Bamboo, 3)}),
+                    TileGroup(TileGroupType::Shuntsu, { *new NumberTile(NumberType::Bamboo, 1), *new NumberTile(NumberType::Bamboo, 2), *new NumberTile(NumberType::Bamboo, 3)}),
+                    TileGroup(TileGroupType::Koutsu, { *new NumberTile(NumberType::Bamboo, 5), *new NumberTile(NumberType::Bamboo, 5), *new NumberTile(NumberType::Bamboo, 5)}),
+                    TileGroup(TileGroupType::Shuntsu, { *new NumberTile(NumberType::Bamboo, 7), *new NumberTile(NumberType::Bamboo, 8), *new NumberTile(NumberType::Bamboo, 9)}),
                 },
                 {
-                    new NumberTile(NumberType::Bamboo, 9),
+                    *new NumberTile(NumberType::Bamboo, 9),
                 }
             };
-            Tile* pickedTile = new NumberTile(NumberType::Bamboo, 9);
+            TileCRef pickedTile = *new NumberTile(NumberType::Bamboo, 9);
             bool isMenzen = true;
             bool isRon    = true;
             WindType roundWind = WindType::East;
@@ -894,19 +893,19 @@ namespace Mini
             puts("[  Yaku Test 04  ]");
             ReassembledTileGroup reassembledTileGroup = {
                 { 
-                    TileGroup(TileGroupType::Head, { new WindTile(WindType::South), new WindTile(WindType::South) }, nullptr, false),
-                    TileGroup(TileGroupType::Head, { new NumberTile(NumberType::Cracks, 1), new NumberTile(NumberType::Cracks, 1) }, nullptr, false),
-                    TileGroup(TileGroupType::Head, { new NumberTile(NumberType::Bamboo, 3), new NumberTile(NumberType::Bamboo, 3) }, nullptr, false),
-                    TileGroup(TileGroupType::Head, { new NumberTile(NumberType::Dots, 7), new NumberTile(NumberType::Dots, 7) }, nullptr, false),
-                    TileGroup(TileGroupType::Head, { new NumberTile(NumberType::Dots, 8), new NumberTile(NumberType::Dots, 8) }, nullptr, false),
-                    TileGroup(TileGroupType::Head, { new WindTile(WindType::West), new WindTile(WindType::West) }, nullptr, false),
+                    TileGroup(TileGroupType::Head, { *new WindTile(WindType::South), *new WindTile(WindType::South) }),
+                    TileGroup(TileGroupType::Head, { *new NumberTile(NumberType::Cracks, 1), *new NumberTile(NumberType::Cracks, 1) }),
+                    TileGroup(TileGroupType::Head, { *new NumberTile(NumberType::Bamboo, 3), *new NumberTile(NumberType::Bamboo, 3) }),
+                    TileGroup(TileGroupType::Head, { *new NumberTile(NumberType::Dots, 7), *new NumberTile(NumberType::Dots, 7) }),
+                    TileGroup(TileGroupType::Head, { *new NumberTile(NumberType::Dots, 8), *new NumberTile(NumberType::Dots, 8) }),
+                    TileGroup(TileGroupType::Head, { *new WindTile(WindType::West), *new WindTile(WindType::West) }),
 
                 },
                 {
-                    new WindTile(WindType::East),
+                    *new WindTile(WindType::East),
                 }
             };
-            Tile* pickedTile = new WindTile(WindType::East);
+            TileCRef pickedTile = *new WindTile(WindType::East);
             bool isMenzen = true;
             bool isRon    = true;
             WindType roundWind = WindType::East;
@@ -948,17 +947,17 @@ namespace Mini
             puts("[  Yaku Test 01  ]");
             ReassembledTileGroup reassembledTileGroup = {
                 { 
-                    TileGroup(TileGroupType::Head, { new WindTile(WindType::South), new WindTile(WindType::South) }, nullptr, false),
-                    TileGroup(TileGroupType::Koutsu, { new NumberTile(NumberType::Cracks, 1), new NumberTile(NumberType::Cracks, 1), new NumberTile(NumberType::Cracks, 1) }, nullptr, false),
-                    TileGroup(TileGroupType::Koutsu, { new NumberTile(NumberType::Bamboo, 2), new NumberTile(NumberType::Bamboo, 2), new NumberTile(NumberType::Bamboo, 2) }, nullptr, false),
-                    TileGroup(TileGroupType::Koutsu, { new NumberTile(NumberType::Dots, 8), new NumberTile(NumberType::Dots, 8), new NumberTile(NumberType::Dots, 8) }, nullptr, false),
+                    TileGroup(TileGroupType::Head, { *new WindTile(WindType::South), *new WindTile(WindType::South) }),
+                    TileGroup(TileGroupType::Koutsu, { *new NumberTile(NumberType::Cracks, 1), *new NumberTile(NumberType::Cracks, 1), *new NumberTile(NumberType::Cracks, 1) }),
+                    TileGroup(TileGroupType::Koutsu, { *new NumberTile(NumberType::Bamboo, 2), *new NumberTile(NumberType::Bamboo, 2), *new NumberTile(NumberType::Bamboo, 2) }),
+                    TileGroup(TileGroupType::Koutsu, { *new NumberTile(NumberType::Dots, 8), *new NumberTile(NumberType::Dots, 8), *new NumberTile(NumberType::Dots, 8) }),
                 },
                 {
-                    new WindTile(WindType::East),
-                    new WindTile(WindType::East)
+                    *new WindTile(WindType::East),
+                    *new WindTile(WindType::East)
                 }
             };
-            Tile* pickedTile = new WindTile(WindType::East);
+            TileCRef pickedTile = *new WindTile(WindType::East);
             bool isMenzen = true;
             bool isRon    = true;
             WindType roundWind = WindType::East;
@@ -971,17 +970,17 @@ namespace Mini
             puts("[  Yaku Test 02  ]");
             ReassembledTileGroup reassembledTileGroup = {
                 { 
-                    TileGroup(TileGroupType::Head, { new WindTile(WindType::South), new WindTile(WindType::South) }, nullptr, false),
-                    TileGroup(TileGroupType::Koutsu, { new NumberTile(NumberType::Cracks, 1), new NumberTile(NumberType::Cracks, 1), new NumberTile(NumberType::Cracks, 1) }, nullptr, false),
-                    TileGroup(TileGroupType::Koutsu, { new NumberTile(NumberType::Bamboo, 2), new NumberTile(NumberType::Bamboo, 2), new NumberTile(NumberType::Bamboo, 2) }, nullptr, false),
-                    TileGroup(TileGroupType::Koutsu, { new NumberTile(NumberType::Dots, 8), new NumberTile(NumberType::Dots, 8), new NumberTile(NumberType::Dots, 8) }, nullptr, false),
+                    TileGroup(TileGroupType::Head, { *new WindTile(WindType::South), *new WindTile(WindType::South) }),
+                    TileGroup(TileGroupType::Koutsu, { *new NumberTile(NumberType::Cracks, 1), *new NumberTile(NumberType::Cracks, 1), *new NumberTile(NumberType::Cracks, 1) }),
+                    TileGroup(TileGroupType::Koutsu, { *new NumberTile(NumberType::Bamboo, 2), *new NumberTile(NumberType::Bamboo, 2), *new NumberTile(NumberType::Bamboo, 2) }),
+                    TileGroup(TileGroupType::Koutsu, { *new NumberTile(NumberType::Dots, 8), *new NumberTile(NumberType::Dots, 8), *new NumberTile(NumberType::Dots, 8) }),
                 },
                 {
-                    new WindTile(WindType::East),
-                    new WindTile(WindType::East)
+                    *new WindTile(WindType::East),
+                    *new WindTile(WindType::East)
                 }
             };
-            Tile* pickedTile = new WindTile(WindType::East);
+            TileCRef pickedTile = *new WindTile(WindType::East);
             bool isMenzen = true;
             bool isRon    = false;
             WindType roundWind = WindType::East;
@@ -994,16 +993,16 @@ namespace Mini
             puts("[  Yaku Test 03  ]");
             ReassembledTileGroup reassembledTileGroup = {
                 { 
-                    TileGroup(TileGroupType::Kangtsu, { new NumberTile(NumberType::Cracks, 1), new NumberTile(NumberType::Cracks, 1), new NumberTile(NumberType::Cracks, 1) }, new NumberTile(NumberType::Cracks, 1), true),
-                    TileGroup(TileGroupType::Koutsu, { new NumberTile(NumberType::Cracks, 4), new NumberTile(NumberType::Cracks, 4), new NumberTile(NumberType::Cracks, 4) }, nullptr, false),
-                    TileGroup(TileGroupType::Koutsu, { new NumberTile(NumberType::Bamboo, 2), new NumberTile(NumberType::Bamboo, 2), new NumberTile(NumberType::Bamboo, 2) }, nullptr, false),
-                    TileGroup(TileGroupType::Koutsu, { new NumberTile(NumberType::Dots, 8), new NumberTile(NumberType::Dots, 8), new NumberTile(NumberType::Dots, 8) }, nullptr, false),
+                    TileGroup(TileGroupType::Kangtsu, { *new NumberTile(NumberType::Cracks, 1), *new NumberTile(NumberType::Cracks, 1), *new NumberTile(NumberType::Cracks, 1) }, *new NumberTile(NumberType::Cracks, 1), true),
+                    TileGroup(TileGroupType::Koutsu, { *new NumberTile(NumberType::Cracks, 4), *new NumberTile(NumberType::Cracks, 4), *new NumberTile(NumberType::Cracks, 4) }),
+                    TileGroup(TileGroupType::Koutsu, { *new NumberTile(NumberType::Bamboo, 2), *new NumberTile(NumberType::Bamboo, 2), *new NumberTile(NumberType::Bamboo, 2) }),
+                    TileGroup(TileGroupType::Koutsu, { *new NumberTile(NumberType::Dots, 8), *new NumberTile(NumberType::Dots, 8), *new NumberTile(NumberType::Dots, 8) }),
                 },
                 {
-                    new WindTile(WindType::East)
+                    *new WindTile(WindType::East)
                 }
             };
-            Tile* pickedTile = new WindTile(WindType::East);
+            TileCRef pickedTile = *new WindTile(WindType::East);
             bool isMenzen = false;
             bool isRon    = true;
             WindType roundWind = WindType::East;
@@ -1016,17 +1015,17 @@ namespace Mini
             puts("[  Yaku Test 04  ]");
             ReassembledTileGroup reassembledTileGroup = {
                 { 
-                    TileGroup(TileGroupType::Head, { new WindTile(WindType::South), new WindTile(WindType::South) }, nullptr, false),
-                    TileGroup(TileGroupType::Kangtsu, { new NumberTile(NumberType::Cracks, 1), new NumberTile(NumberType::Cracks, 1), new NumberTile(NumberType::Cracks, 1) }, new NumberTile(NumberType::Cracks, 1), true),
-                    TileGroup(TileGroupType::Koutsu, { new NumberTile(NumberType::Bamboo, 2), new NumberTile(NumberType::Bamboo, 2), new NumberTile(NumberType::Bamboo, 2) }, nullptr, false),
-                    TileGroup(TileGroupType::Koutsu, { new NumberTile(NumberType::Dots, 8), new NumberTile(NumberType::Dots, 8), new NumberTile(NumberType::Dots, 8) }, nullptr, false),
+                    TileGroup(TileGroupType::Head, { *new WindTile(WindType::South), *new WindTile(WindType::South) }),
+                    TileGroup(TileGroupType::Kangtsu, { *new NumberTile(NumberType::Cracks, 1), *new NumberTile(NumberType::Cracks, 1), *new NumberTile(NumberType::Cracks, 1) }, *new NumberTile(NumberType::Cracks, 1), true),
+                    TileGroup(TileGroupType::Koutsu, { *new NumberTile(NumberType::Bamboo, 2), *new NumberTile(NumberType::Bamboo, 2), *new NumberTile(NumberType::Bamboo, 2) }),
+                    TileGroup(TileGroupType::Koutsu, { *new NumberTile(NumberType::Dots, 8), *new NumberTile(NumberType::Dots, 8), *new NumberTile(NumberType::Dots, 8) }),
                 },
                 {
-                    new WindTile(WindType::East),
-                    new WindTile(WindType::East)
+                    *new WindTile(WindType::East),
+                    *new WindTile(WindType::East)
                 }
             };
-            Tile* pickedTile = new WindTile(WindType::East);
+            TileCRef pickedTile = *new WindTile(WindType::East);
             bool isMenzen = false;
             bool isRon    = true;
             WindType roundWind = WindType::East;
@@ -1037,7 +1036,7 @@ namespace Mini
     }
 
     /* Utility for Test */
-    void CalcAndPrintYaku(std::vector<Yaku*> yakuList, const ReassembledTileGroup& reassembledTileGroup, Tile* pickedTile, bool isMenzen, bool isRon, WindType roundWind, WindType selfWind)
+    void CalcAndPrintYaku(std::vector<Yaku*> yakuList, const ReassembledTileGroup& reassembledTileGroup, const Tile& pickedTile, bool isMenzen, bool isRon, WindType roundWind, WindType selfWind)
     {
         printf(" ( RoundWind: %s, SelfWind: %s )\n", GetWindTypeString(roundWind).c_str(), GetWindTypeString(selfWind).c_str());
         printf("Tiles: ");
@@ -1046,11 +1045,11 @@ namespace Mini
             tileGroup.Sort();
             printf("%s ", tileGroup.ToString().c_str());
         }
-        for (auto& tile: reassembledTileGroup.restTiles)
+        for (const Tile& tile: reassembledTileGroup.restTiles)
         {
-            printf("%s ", tile->ToString().c_str());
+            printf("%s ", tile.ToString().c_str());
         }
-        printf("    %s (%s)\n", pickedTile->ToString().c_str(), isRon ? "Ron" : "Tsumo");
+        printf("    %s (%s)\n", pickedTile.ToString().c_str(), isRon ? "Ron" : "Tsumo");
 
         int totalScore = 0;
         std::vector<std::pair<Yaku*, int>> countedYakuList;

--- a/Test/Test.h
+++ b/Test/Test.h
@@ -19,7 +19,7 @@ namespace Mini
     void Test10();
 
     /* Utility for Test */
-    void CalcAndPrintYaku(std::vector<Yaku*> yakuList, const ReassembledTileGroup& reassembledTileGroup, Tile* pickedTile, bool isMenzen, bool isRon, WindType roundWind, WindType selfWind);
+    void CalcAndPrintYaku(std::vector<Yaku*> yakuList, const ReassembledTileGroup& reassembledTileGroup, const Tile& pickedTile, bool isMenzen, bool isRon, WindType roundWind, WindType selfWind);
 }
 
 #endif // __MINI_MAHJONG_TEST_H__


### PR DESCRIPTION
This PR proposes using reference wrappers instead of pointers for `Tile` class.
```
// before
std::vector<Tile*> tile;
// after
TileCRef = std::reference_wrapper<const Tile>; // in Tile.h
std::vector<TileCRef> tiles;
```

I have noticed that there's more pointer usage which is replaceable, but this PR only replaces `Tile` class.